### PR TITLE
Fix: Adjust BottomBar for mobile safe areas

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,6 +19,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="pl" suppressHydrationWarning>
+      <head>
+          {/* Poprawiona meta tag viewport */}
+          <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+      </head>
       <body className={cn("antialiased", inter.className)}>
         <Providers>
           <AppLayout>{children}</AppLayout>


### PR DESCRIPTION
Adds the `viewport-fit=cover` meta tag to the main layout. This allows the browser to correctly calculate the `env(safe-area-inset-bottom)` CSS variable, which is used to adjust the height of the bottom bar.

This change fixes an issue where the bottom bar was being partially cut off on mobile devices with system gesture bars or other safe area insets.