### PR TITLE
feat: Redesign video info display

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -11,6 +11,7 @@
     --transition-timing: cubic-bezier(0.25, 0.46, 0.45, 0.94);
     --topbar-base-height: 40px;
     --bottombar-base-height: 110px;
+    --sidebar-width: 90px;
     --safe-area-top: env(safe-area-inset-top);
     --safe-area-bottom: env(safe-area-inset-bottom);
     --topbar-height: calc(var(--topbar-base-height) + var(--safe-area-top));

--- a/components/BottomBar.tsx
+++ b/components/BottomBar.tsx
@@ -2,13 +2,11 @@ import React, { useState, useEffect, useRef } from 'react';
 
 // Props interface remains the same
 interface BottomBarProps {
-  user: string;
-  description: string;
   videoRef: React.RefObject<HTMLVideoElement>;
   isActive: boolean;
 }
 
-const BottomBar: React.FC<BottomBarProps> = ({ user, description, videoRef, isActive }) => {
+const BottomBar: React.FC<BottomBarProps> = ({ videoRef, isActive }) => {
   // Re-integrate state and refs from the original component's logic
   const [progress, setProgress] = useState(0);
   const [isDragging, setIsDragging] = useState(false);
@@ -99,20 +97,14 @@ const BottomBar: React.FC<BottomBarProps> = ({ user, description, videoRef, isAc
         </div>
         {/* Draggable dot/handle */}
         <div
-          className="absolute top-1/2 w-3.5 h-3.5 bg-primary border-2 border-white rounded-full opacity-0 group-hover:opacity-100 transition-opacity"
+          className="absolute top-1/2 w-3.5 h-3.5 bg-primary border-2 border-white rounded-full opacity-100"
           style={{
             left: `${progress}%`,
             transform: 'translate(-50%, -50%)',
             boxShadow: '0 0 6px rgba(255, 255, 255, 0.6)',
-            transition: isDragging ? 'none' : 'left 0.1s linear, opacity 0.2s',
+            transition: isDragging ? 'none' : 'left 0.1s linear',
           }}
         />
-      </div>
-
-      {/* This div represents the '.text-info' container */}
-      <div className="flex-none min-w-0" style={{ textShadow: '0 0 4px rgba(0, 0, 0, 0.8)' }}>
-        <h3 className="text-lg font-bold mb-1 leading-tight">@{user}</h3>
-        <p className="text-sm leading-snug whitespace-normal">{description}</p>
       </div>
     </div>
   );

--- a/components/Slide.tsx
+++ b/components/Slide.tsx
@@ -5,6 +5,7 @@ import { useUser } from '@/context/UserContext';
 import VideoPlayer from './VideoPlayer';
 import Sidebar from './Sidebar';
 import BottomBar from './BottomBar';
+import VideoInfo from './VideoInfo';
 import TopBar from './TopBar';
 import { Lock } from 'lucide-react';
 
@@ -76,7 +77,8 @@ const Slide: React.FC<SlideProps> = ({ slide, isActive, setIsModalOpen, openAcco
           openInfoModal={openInfoModal}
           openAccountPanel={openAccountPanel}
         />
-        <BottomBar user={slide.user} description={slide.description} videoRef={videoRef} isActive={isActive && !showSecretOverlay} />
+        <VideoInfo user={slide.user} description={slide.description} />
+        <BottomBar videoRef={videoRef} isActive={isActive && !showSecretOverlay} />
       </div>
     </div>
   );

--- a/components/VideoInfo.tsx
+++ b/components/VideoInfo.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import React, { useState, useRef, useEffect } from 'react';
+import { ChevronUp } from 'lucide-react';
+
+interface VideoInfoProps {
+  user: string;
+  description: string;
+}
+
+const VideoInfo: React.FC<VideoInfoProps> = ({ user, description }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isClamped, setIsClamped] = useState(false);
+  const descriptionRef = useRef<HTMLParagraphElement>(null);
+
+  // This effect checks if the description text is taller than the space available
+  // for two lines, and if so, sets the state to show the "more" button.
+  useEffect(() => {
+    const checkClamp = () => {
+      if (descriptionRef.current) {
+        // Temporarily remove line-clamp to measure full height
+        descriptionRef.current.classList.remove('line-clamp-2');
+        const isOverflowing = descriptionRef.current.scrollHeight > descriptionRef.current.clientHeight;
+        setIsClamped(descriptionRef.current.scrollHeight > 80); // Heuristic check, adjust as needed
+        // Re-apply line-clamp
+        if (!isExpanded) {
+            descriptionRef.current.classList.add('line-clamp-2');
+        }
+      }
+    };
+
+    const checkInitialClamp = () => {
+        if (descriptionRef.current) {
+            const lineHeight = parseInt(window.getComputedStyle(descriptionRef.current).lineHeight, 10);
+            const isOverflowing = descriptionRef.current.scrollHeight > lineHeight * 2;
+            setIsClamped(isOverflowing);
+        }
+    }
+
+    // A slight delay is needed to ensure correct measurement after render
+    const timeoutId = setTimeout(checkInitialClamp, 100);
+
+    window.addEventListener('resize', checkInitialClamp);
+    return () => {
+        clearTimeout(timeoutId);
+        window.removeEventListener('resize', checkInitialClamp);
+    }
+  }, [description, isExpanded]);
+
+  const toggleExpand = (e: React.MouseEvent) => {
+    e.stopPropagation(); // Prevent the click from propagating to parent elements
+    setIsExpanded(!isExpanded);
+  };
+
+  // If the user clicks outside the expanded info box, it should collapse.
+  const handleCollapse = () => {
+    if (isExpanded) {
+      setIsExpanded(false);
+    }
+  };
+
+  return (
+    <>
+      {/* Clickable overlay to collapse the description when it's expanded */}
+      {isExpanded && <div className="fixed inset-0 z-[106]" onClick={handleCollapse} />}
+
+      {/* Main container for the info box */}
+      <div
+        className="absolute bottom-[var(--bottombar-base-height)] left-0 right-[var(--sidebar-width)] z-[107] text-white p-3 cursor-pointer"
+        style={{ textShadow: '0 1px 4px rgba(0,0,0,0.7)' }}
+        onClick={!isExpanded && isClamped ? toggleExpand : undefined}
+      >
+        <div className={`transition-all duration-300 ease-in-out ${isExpanded ? 'bg-black/40 backdrop-blur-sm rounded-lg p-4 max-h-[40vh] overflow-y-auto cursor-default' : 'max-h-[80px] overflow-hidden'}`}>
+            <h3 className="text-base font-bold leading-tight mb-1">@{user}</h3>
+
+            <p
+              ref={descriptionRef}
+              className={`text-sm leading-snug whitespace-pre-wrap ${!isExpanded ? 'line-clamp-2' : ''}`}
+            >
+              {description}
+            </p>
+
+            {isClamped && !isExpanded && (
+                <button
+                    className="text-white font-semibold text-sm"
+                >
+                    ...more
+                </button>
+            )}
+
+            {isExpanded && (
+                <button
+                    onClick={toggleExpand}
+                    className="text-white font-semibold text-sm mt-2 flex items-center"
+                >
+                    Less <ChevronUp size={20} className="ml-1" />
+                </button>
+            )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default VideoInfo;

--- a/dev.log
+++ b/dev.log
@@ -1,9 +1,0 @@
-
-> ting-tong-next@0.1.0 dev
-> next dev
-
-  ▲ Next.js 14.2.3
-  - Local:        http://localhost:3000
-  - Environments: .env.local
-
- ✓ Starting...


### PR DESCRIPTION
Moves the author and description from the BottomBar to a new, separate VideoInfo component positioned above the progress bar.

The new VideoInfo component displays the author's name and a description that is truncated to two lines. If the description is longer, a '...more' button is shown, which expands the component to reveal the full text.

The BottomBar component is refactored to remove the user and description logic, leaving it as a container for the progress bar and future elements.

The progress bar handle is made permanently visible.

This change ensures the video information is always visible, including on 'secret' slides for non-logged-in users, and provides a better user experience for long descriptions, inspired by modern video platforms.