### PR TITLE
Fix: Adjust BottomBar layout and height

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -10,7 +10,7 @@
     --transition-speed: 0.4s;
     --transition-timing: cubic-bezier(0.25, 0.46, 0.45, 0.94);
     --topbar-base-height: 40px;
-    --bottombar-base-height: 110px;
+    --bottombar-base-height: 130px;
     --sidebar-width: 90px;
     --safe-area-top: env(safe-area-inset-top);
     --safe-area-bottom: env(safe-area-inset-bottom);

--- a/components/BottomBar.tsx
+++ b/components/BottomBar.tsx
@@ -77,7 +77,7 @@ const BottomBar: React.FC<BottomBarProps> = ({ videoRef, isActive, openInfoModal
   // The main container for the bottom bar, styled to match the prototype
   return (
     <div
-      className="absolute bottom-0 left-0 w-full z-[105] flex flex-col justify-end text-white"
+      className="absolute bottom-0 left-0 w-full z-[105] flex flex-col justify-start text-white"
       style={{
         padding: '10px 10px calc(10px + var(--safe-area-bottom)) 12px',
         minHeight: 'var(--bottombar-base-height)',
@@ -119,7 +119,7 @@ const BottomBar: React.FC<BottomBarProps> = ({ videoRef, isActive, openInfoModal
       </div>
 
       {/* New Button Panel */}
-      <div className="flex justify-center items-center gap-4 pt-2">
+      <div className="flex justify-around items-center pt-2">
         <button onClick={handleTipClick} className="flex flex-col items-center gap-0.5 text-white text-xs font-semibold">
           <Coffee size={28} className="stroke-white" style={{ filter: 'drop-shadow(0 0 3px rgba(0,0,0,0.5))' }}/>
           <span className="icon-label">{t('tipText') || 'Tip'}</span>


### PR DESCRIPTION
This commit addresses issues with the BottomBar component to better align with user requirements and fix mobile layout problems.

- Increased the base height of the BottomBar by changing the `--bottombar-base-height` variable from 110px to 130px in `app/globals.css`.
- Changed the vertical alignment of the BottomBar's content from `justify-end` to `justify-start` to prevent icons from being pushed off-screen on mobile devices.
- Changed the horizontal alignment of the icons from `justify-center` to `justify-around` to distribute them evenly across the screen width, as requested.