### PR TITLE
Fix: Update sidebar icon gap to 6px

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -82,7 +82,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 
   return (
     <aside
-      className="absolute right-0 flex flex-col items-center gap-[1.5rem] z-20"
+      className="absolute right-0 flex flex-col items-center gap-[6px] z-20"
       style={{
         top: 'calc((var(--app-height) - var(--topbar-height) - var(--bottombar-height)) / 2 + var(--topbar-height))',
         transform: 'translateY(-50%)',


### PR DESCRIPTION
Changed the gap between icons in the sidebar from 1.5rem to 6px as requested. This was done by updating the Tailwind CSS utility class in the Sidebar.tsx component.