### PR TITLE
feat: Add Pope Game and Typing Challenge slides

### DIFF
--- a/components/HtmlContent.tsx
+++ b/components/HtmlContent.tsx
@@ -4,6 +4,8 @@ import React, { useMemo } from 'react';
 import { HtmlSlideData } from '@/lib/types';
 import DOMPurify from 'dompurify';
 import VideoInfo from './VideoInfo';
+import PopeGame from './PopeGame';
+import TypingChallenge from './TypingChallenge';
 
 interface HtmlContentProps {
   data: HtmlSlideData;
@@ -11,27 +13,35 @@ interface HtmlContentProps {
 }
 
 const HtmlContent: React.FC<HtmlContentProps> = ({ data, username }) => {
-  const sanitizedHtml = useMemo(() => {
-    // Check if running in a browser environment before using DOMPurify
-    if (typeof window !== 'undefined') {
-      return DOMPurify.sanitize(data.htmlContent);
-    }
-    return ''; // Return empty string for server-side rendering
-  }, [data.htmlContent]);
+  switch (data.type) {
+    case 'GAME_POPE':
+      return <PopeGame gameData={data.gameData} />;
+    case 'TYPING_CHALLENGE':
+      return <TypingChallenge challengeData={data.challengeData} />;
+    default: {
+      const sanitizedHtml = useMemo(() => {
+        // Check if running in a browser environment before using DOMPurify
+        if (typeof window !== 'undefined' && data.htmlContent) {
+          return DOMPurify.sanitize(data.htmlContent);
+        }
+        return ''; // Return empty string for server-side rendering or if htmlContent is not available
+      }, [data.htmlContent]);
 
-  return (
-    <div className="h-full w-full relative bg-black">
-      <div
-        className="w-full h-full"
-        dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
-      />
-      {data.description && (
-        <div className="absolute bottom-20 left-2 right-2">
-           <VideoInfo user={username} description={data.description} />
+      return (
+        <div className="h-full w-full relative bg-black">
+          <div
+            className="w-full h-full"
+            dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
+          />
+          {data.description && (
+            <div className="absolute bottom-20 left-2 right-2">
+              <VideoInfo user={username} description={data.description} />
+            </div>
+          )}
         </div>
-      )}
-    </div>
-  );
+      );
+    }
+  }
 };
 
 export default HtmlContent;

--- a/components/PopeGame.tsx
+++ b/components/PopeGame.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import React, { useState, useEffect } from 'react';
+import { PopeGameData } from '@/lib/types';
+import { Button } from '@/components/ui/button';
+
+interface PopeGameProps {
+  gameData: PopeGameData;
+}
+
+const RobotRobert = ({ text }: { text: string }) => {
+  return (
+    <div className="p-4 bg-gray-800 rounded-lg">
+      <p className="text-white text-center">{text}</p>
+    </div>
+  );
+};
+
+const PopeGame: React.FC<PopeGameProps> = ({ gameData }) => {
+  const [gameState, setGameState] = useState<'intro' | 'playing' | 'finished'>('intro');
+  const [currentRound, setCurrentRound] = useState(0);
+  const [score, setScore] = useState(0);
+  const [currentScenario, setCurrentScenario] = useState(gameData.scenarios[0]);
+  const [finalTitle, setFinalTitle] = useState('');
+  const [isChoiceMade, setIsChoiceMade] = useState(false);
+
+  useEffect(() => {
+    if (gameState === 'playing' && !isChoiceMade) {
+      if (currentRound < gameData.scenarios.length) {
+        setCurrentScenario(gameData.scenarios[currentRound]);
+      } else if (currentRound === gameData.scenarios.length) {
+        setCurrentScenario(gameData.bossFight);
+      } else {
+        setGameState('finished');
+      }
+    }
+  }, [gameState, currentRound, gameData, isChoiceMade]);
+
+  useEffect(() => {
+    if (gameState === 'finished') {
+      if (score < 10) {
+        setFinalTitle('Papież Sarkastycznej Dobroci');
+      } else if (score < 15) {
+        setFinalTitle('Papież Neutralnego Pokoju');
+      } else {
+        setFinalTitle('Papież Prawdziwej Świętości');
+      }
+    }
+  }, [gameState, score]);
+
+  const handleChoice = (choice: 'dopyskuj' | 'powiedz_milo') => {
+    if (isChoiceMade) return;
+
+    if (choice === 'dopyskuj') {
+      setScore(s => s + 3);
+    } else {
+      setScore(s => s + 5);
+    }
+    setIsChoiceMade(true);
+
+    setTimeout(() => {
+      setCurrentRound(r => r + 1);
+      setIsChoiceMade(false);
+    }, 2000);
+  };
+
+  const startGame = () => {
+    setGameState('playing');
+    setCurrentRound(0);
+    setScore(0);
+    setIsChoiceMade(false);
+  };
+
+  const renderContent = () => {
+    switch (gameState) {
+      case 'intro':
+        return (
+          <div className="flex flex-col items-center justify-center h-full">
+            <RobotRobert text="Witaj w grze 'Papież: Gra w bycie miłym'. Kliknij START, aby rozpocząć." />
+            <Button onClick={startGame} className="mt-4">START GAME</Button>
+          </div>
+        );
+      case 'playing':
+        return (
+          <div className="flex flex-col items-center justify-center h-full p-4">
+            <RobotRobert text={currentScenario.text} />
+            <div className="flex mt-4">
+              <Button onClick={() => handleChoice('dopyskuj')} className="mr-2" disabled={isChoiceMade}>
+                {currentScenario.choices.dopyskuj}
+              </Button>
+              <Button onClick={() => handleChoice('powiedz_milo')} disabled={isChoiceMade}>
+                {currentScenario.choices.powiedz_milo}
+              </Button>
+            </div>
+            {isChoiceMade && <p className="text-white mt-4">Chwila namysłu...</p>}
+          </div>
+        );
+      case 'finished':
+        return (
+          <div className="flex flex-col items-center justify-center h-full">
+            <RobotRobert text={`Koniec gry! Twój wynik to: ${score}.`} />
+            <h2 className="text-2xl text-white mt-4">{finalTitle}</h2>
+            <Button onClick={startGame} className="mt-4">Zagraj ponownie</Button>
+          </div>
+        );
+    }
+  };
+
+  return (
+    <div className="h-full w-full bg-black text-white">
+      {renderContent()}
+    </div>
+  );
+};
+
+export default PopeGame;

--- a/components/TypingChallenge.tsx
+++ b/components/TypingChallenge.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { TypingChallengeData } from '@/lib/types';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+interface TypingChallengeProps {
+  challengeData: TypingChallengeData;
+}
+
+const TypingChallenge: React.FC<TypingChallengeProps> = ({ challengeData }) => {
+  const [currentPhrase, setCurrentPhrase] = useState('');
+  const [userInput, setUserInput] = useState('');
+  const [isTyping, setIsTyping] = useState(false);
+  const [startTime, setStartTime] = useState<number | null>(null);
+  const [wpm, setWpm] = useState(0);
+  const [finalTitle, setFinalTitle] = useState<string | null>(null);
+  const [isFinished, setIsFinished] = useState(false);
+
+  const selectNewPhrase = useCallback(() => {
+    const randomIndex = Math.floor(Math.random() * challengeData.phrases.length);
+    setCurrentPhrase(challengeData.phrases[randomIndex]);
+  }, [challengeData.phrases]);
+
+  useEffect(() => {
+    selectNewPhrase();
+  }, [selectNewPhrase]);
+
+  const resetTest = () => {
+    selectNewPhrase();
+    setUserInput('');
+    setIsTyping(false);
+    setStartTime(null);
+    setWpm(0);
+    setFinalTitle(null);
+    setIsFinished(false);
+  };
+
+  const calculateWPM = (timeTaken: number) => {
+    const words = currentPhrase.split(' ').length;
+    const minutes = timeTaken / 1000 / 60;
+    return Math.round(words / minutes);
+  };
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setUserInput(value);
+
+    if (!isTyping && value.length > 0) {
+      setIsTyping(true);
+      setStartTime(Date.now());
+    }
+
+    if (value === currentPhrase) {
+      setIsFinished(true);
+      if (startTime) {
+        const endTime = Date.now();
+        const timeTaken = endTime - startTime;
+        const calculatedWpm = calculateWPM(timeTaken);
+        setWpm(calculatedWpm);
+
+        if (calculatedWpm < 30) {
+          setFinalTitle(challengeData.titles.slow);
+        } else if (calculatedWpm < 60) {
+          setFinalTitle(challengeData.titles.average);
+        } else if (calculatedWpm < 90) {
+          setFinalTitle(challengeData.titles.fast);
+        } else {
+          setFinalTitle(challengeData.titles.insane);
+        }
+      }
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center h-full w-full bg-gray-900 text-white p-4">
+      <h1 className="text-2xl font-bold mb-4">Wielki Test Szybkości Pisania</h1>
+      <div className="p-4 bg-gray-800 rounded-lg mb-4">
+        <p className="text-lg text-center font-mono">{currentPhrase}</p>
+      </div>
+      <Input
+        type="text"
+        value={userInput}
+        onChange={handleInputChange}
+        placeholder="Zacznij pisać tutaj..."
+        className="w-full max-w-md text-black"
+        disabled={isFinished}
+      />
+      {isFinished ? (
+        <div className="text-center mt-4">
+          <h2 className="text-xl">Gratulacje!</h2>
+          <p className="text-3xl font-bold">{wpm} WPM</p>
+          <p className="text-lg mt-2">{finalTitle}</p>
+          <Button onClick={resetTest} className="mt-4">
+            Spróbuj jeszcze raz
+          </Button>
+        </div>
+      ) : (
+        <p className="mt-4 text-gray-400">Powodzenia!</p>
+      )}
+    </div>
+  );
+};
+
+export default TypingChallenge;

--- a/lib/mock-data.ts
+++ b/lib/mock-data.ts
@@ -1,4 +1,4 @@
-import type { Grid } from './types';
+import type { Grid, Slide } from './types';
 
 // Create a grid of mock slides with different types
 export const mockGrid: Grid = {
@@ -89,3 +89,92 @@ export const mockGrid: Grid = {
     },
   },
 };
+
+const papiezGameSlide: Slide = {
+    id: 'papiez-game',
+    type: 'html', // It's an html slide, so it will be rendered by HtmlContent
+    userId: 'user_pope_game',
+    username: 'Papież Programista',
+    avatar: 'https://i.pravatar.cc/150?u=user_pope_game',
+    access: 'public',
+    createdAt: Date.now(),
+    initialLikes: 2137,
+    isLiked: false,
+    initialComments: 37,
+    x: 3,
+    y: 3,
+    data: {
+        description: 'Papież: Gra w bycie miłym',
+        type: 'GAME_POPE', // The new custom type inside data
+        gameData: {
+            scenarios: [
+                {
+                    text: 'Ktoś próbuje Ci wcisnąć zestaw naczyń „Ceper”. Na koniec mówi, że to dar od Niebios.',
+                    choices: {
+                        'dopyskuj': '+3 punkty',
+                        'powiedz_milo': '+5 punktów'
+                    }
+                },
+                {
+                    text: 'Idziesz w tłumie, a jakiś typ daje Ci kuksańca, po czym krzyczy, że to pozdrowienie od kibiców z Krakowa.',
+                    choices: {
+                        'dopyskuj': '+3 punkty',
+                        'powiedz_milo': '+5 punktów'
+                    }
+                },
+                {
+                    text: 'Młody chłopak podchodzi do Ciebie i pyta, czy masz 2 złote na bułkę. W tle słychać, jak jego kolega szepcze: „na browara mu daj!”',
+                    choices: {
+                        'dopyskuj': '+3 punkty',
+                        'powiedz_milo': '+5 punktów'
+                    }
+                },
+            ],
+            bossFight: {
+                text: '„Boss Fight”: Zbliża się do Ciebie Kardynał i pyta: „Co właściwie robisz na Tingtongu?”',
+                choices: {
+                    'dopyskuj': '+3 punkty',
+                    'powiedz_milo': '+5 punktów'
+                }
+            }
+        }
+    }
+};
+
+mockGrid['3,3'] = papiezGameSlide;
+
+const typingChallengeSlide: Slide = {
+    id: 'typing-challenge',
+    type: 'html',
+    userId: 'user_typing_challenge',
+    username: 'Klawiaturowy Mistrz',
+    avatar: 'https://i.pravatar.cc/150?u=user_typing_challenge',
+    access: 'public',
+    createdAt: Date.now(),
+    initialLikes: 1337,
+    isLiked: false,
+    initialComments: 101,
+    x: 3,
+    y: 4,
+    data: {
+        description: 'Wielki Test Szybkości Pisania',
+        type: 'TYPING_CHALLENGE',
+        challengeData: {
+            phrases: [
+                'Jednorożce programują w C++',
+                'Moja grzywka jest binarna i na dodatek gubi pakiety.',
+                'Kot Schrödingera zagrał w szachy z Einsteinem i obaj byli martwi.',
+                'Wczorajsze pierogi są dziś chmurą obliczeniową.',
+                'AI oskarżyło mnie o zbyt dużą kreatywność i zaczęło mrugać literą B.',
+            ],
+            titles: {
+                slow: 'Programista-Poeta (pisze wolno, ale z uczuciem)',
+                average: 'Mistrz Klawiatury (zrobi to, ale bez fajerwerków)',
+                fast: 'Turbo-Pikselowy Ninja (szybszy niż błąd w kompilacji)',
+                insane: 'AI-Szybki Klawiaturowy Absurdysta!',
+            }
+        }
+    }
+};
+
+mockGrid['3,4'] = typingChallengeSlide;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -32,11 +32,50 @@ export interface VideoSlide extends BaseSlide {
   data: VideoSlideData;
 }
 
-// Specific data for an HTML slide
-export interface HtmlSlideData {
-  htmlContent: string;
-  description?: string; // Optional description for HTML slides
+// Specific data for the Pope Game
+interface PopeGameScenario {
+  text: string;
+  choices: {
+    dopyskuj: string;
+    powiedz_milo: string;
+  };
 }
+
+export interface PopeGameData {
+  scenarios: PopeGameScenario[];
+  bossFight: PopeGameScenario;
+}
+
+// Specific data for the Typing Challenge
+export interface TypingChallengeData {
+  phrases: string[];
+  titles: {
+    slow: string;
+    average: string;
+    fast: string;
+    insane: string;
+  };
+}
+
+// Specific data for an HTML slide, which can be regular HTML or a game
+export type HtmlSlideData = {
+  description?: string; // Optional description for HTML slides
+} & (
+  | {
+      htmlContent: string;
+      type?: undefined; // Regular HTML slides don't have a 'type' in data
+    }
+  | {
+      htmlContent?: never;
+      type: 'GAME_POPE';
+      gameData: PopeGameData;
+    }
+  | {
+      htmlContent?: never;
+      type: 'TYPING_CHALLENGE';
+      challengeData: TypingChallengeData;
+    }
+);
 
 // HTML slide type
 export interface HtmlSlide extends BaseSlide {


### PR DESCRIPTION
This commit introduces two new interactive slide types to the application:

1.  **Pope Game (`GAME_POPE`):**
    *   A scenario-based game where the user makes choices as the Pope.
    *   Includes a new `PopeGame.tsx` component to manage game state and logic.
    *   Integrated into `HtmlContent.tsx` to render based on the slide data type.

2.  **Typing Challenge (`TYPING_CHALLENGE`):**
    *   A speed-typing test with absurd phrases.
    *   Calculates words per minute (WPM) and assigns a title based on performance.
    *   Includes a new `TypingChallenge.tsx` component.
    *   `HtmlContent.tsx` has been refactored to use a switch statement to handle multiple custom slide types.

Both features have been implemented according to the provided specifications. The necessary type definitions in `lib/types.ts` and mock data in `lib/mock-data.ts` have been added.