### PR TITLE
feat: Create 9x9 presentation prototype

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,128 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<title>Prezentacja 9x9</title>
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@5.2.1/dist/reveal.css">
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@5.2.1/dist/theme/black.css" id="theme">
+		<link rel="stylesheet" href="style.css">
+	</head>
+	<body>
+		<div class="reveal">
+			<div class="slides">
+				<section>
+					<section class="bg-1-1"><h2>Slajd 1.1</h2><p>Autor: Jules</p><p class="description">Opis slajdu 1.1</p></section>
+					<section class="bg-1-2"><h2>Slajd 1.2</h2><p>Autor: Jules</p><p class="description">Opis slajdu 1.2</p></section>
+					<section class="bg-1-3"><h2>Slajd 1.3</h2><p>Autor: Jules</p><p class="description">Opis slajdu 1.3</p></section>
+					<section class="bg-1-4"><h2>Slajd 1.4</h2><p>Autor: Jules</p><p class="description">Opis slajdu 1.4</p></section>
+					<section class="bg-1-5"><h2>Slajd 1.5</h2><p>Autor: Jules</p><p class="description">Opis slajdu 1.5</p></section>
+					<section class="bg-1-6"><h2>Slajd 1.6</h2><p>Autor: Jules</p><p class="description">Opis slajdu 1.6</p></section>
+					<section class="bg-1-7"><h2>Slajd 1.7</h2><p>Autor: Jules</p><p class="description">Opis slajdu 1.7</p></section>
+					<section class="bg-1-8"><h2>Slajd 1.8</h2><p>Autor: Jules</p><p class="description">Opis slajdu 1.8</p></section>
+					<section class="bg-1-9"><h2>Slajd 1.9</h2><p>Autor: Jules</p><p class="description">Opis slajdu 1.9</p></section>
+				</section>
+				<section>
+					<section class="bg-2-1"><h2>Slajd 2.1</h2><p>Autor: Jules</p><p class="description">Opis slajdu 2.1</p></section>
+					<section class="bg-2-2"><h2>Slajd 2.2</h2><p>Autor: Jules</p><p class="description">Opis slajdu 2.2</p></section>
+					<section class="bg-2-3"><h2>Slajd 2.3</h2><p>Autor: Jules</p><p class="description">Opis slajdu 2.3</p></section>
+					<section class="bg-2-4"><h2>Slajd 2.4</h2><p>Autor: Jules</p><p class="description">Opis slajdu 2.4</p></section>
+					<section class="bg-2-5"><h2>Slajd 2.5</h2><p>Autor: Jules</p><p class="description">Opis slajdu 2.5</p></section>
+					<section class="bg-2-6"><h2>Slajd 2.6</h2><p>Autor: Jules</p><p class="description">Opis slajdu 2.6</p></section>
+					<section class="bg-2-7"><h2>Slajd 2.7</h2><p>Autor: Jules</p><p class="description">Opis slajdu 2.7</p></section>
+					<section class="bg-2-8"><h2>Slajd 2.8</h2><p>Autor: Jules</p><p class="description">Opis slajdu 2.8</p></section>
+					<section class="bg-2-9"><h2>Slajd 2.9</h2><p>Autor: Jules</p><p class="description">Opis slajdu 2.9</p></section>
+				</section>
+				<section>
+					<section class="bg-3-1"><h2>Slajd 3.1</h2><p>Autor: Jules</p><p class="description">Opis slajdu 3.1</p></section>
+					<section class="bg-3-2"><h2>Slajd 3.2</h2><p>Autor: Jules</p><p class="description">Opis slajdu 3.2</p></section>
+					<section class="bg-3-3"><h2>Slajd 3.3</h2><p>Autor: Jules</p><p class="description">Opis slajdu 3.3</p></section>
+					<section class="bg-3-4"><h2>Slajd 3.4</h2><p>Autor: Jules</p><p class="description">Opis slajdu 3.4</p></section>
+					<section class="bg-3-5"><h2>Slajd 3.5</h2><p>Autor: Jules</p><p class="description">Opis slajdu 3.5</p></section>
+					<section class="bg-3-6"><h2>Slajd 3.6</h2><p>Autor: Jules</p><p class="description">Opis slajdu 3.6</p></section>
+					<section class="bg-3-7"><h2>Slajd 3.7</h2><p>Autor: Jules</p><p class="description">Opis slajdu 3.7</p></section>
+					<section class="bg-3-8"><h2>Slajd 3.8</h2><p>Autor: Jules</p><p class="description">Opis slajdu 3.8</p></section>
+					<section class="bg-3-9"><h2>Slajd 3.9</h2><p>Autor: Jules</p><p class="description">Opis slajdu 3.9</p></section>
+				</section>
+				<section>
+					<section class="bg-4-1"><h2>Slajd 4.1</h2><p>Autor: Jules</p><p class="description">Opis slajdu 4.1</p></section>
+					<section class="bg-4-2"><h2>Slajd 4.2</h2><p>Autor: Jules</p><p class="description">Opis slajdu 4.2</p></section>
+					<section class="bg-4-3"><h2>Slajd 4.3</h2><p>Autor: Jules</p><p class="description">Opis slajdu 4.3</p></section>
+					<section class="bg-4-4"><h2>Slajd 4.4</h2><p>Autor: Jules</p><p class="description">Opis slajdu 4.4</p></section>
+					<section class="bg-4-5"><h2>Slajd 4.5</h2><p>Autor: Jules</p><p class="description">Opis slajdu 4.5</p></section>
+					<section class="bg-4-6"><h2>Slajd 4.6</h2><p>Autor: Jules</p><p class="description">Opis slajdu 4.6</p></section>
+					<section class="bg-4-7"><h2>Slajd 4.7</h2><p>Autor: Jules</p><p class="description">Opis slajdu 4.7</p></section>
+					<section class="bg-4-8"><h2>Slajd 4.8</h2><p>Autor: Jules</p><p class="description">Opis slajdu 4.8</p></section>
+					<section class="bg-4-9"><h2>Slajd 4.9</h2><p>Autor: Jules</p><p class="description">Opis slajdu 4.9</p></section>
+				</section>
+				<section>
+					<section class="bg-5-1"><h2>Slajd 5.1</h2><p>Autor: Jules</p><p class="description">Opis slajdu 5.1</p></section>
+					<section class="bg-5-2"><h2>Slajd 5.2</h2><p>Autor: Jules</p><p class="description">Opis slajdu 5.2</p></section>
+					<section class="bg-5-3"><h2>Slajd 5.3</h2><p>Autor: Jules</p><p class="description">Opis slajdu 5.3</p></section>
+					<section class="bg-5-4"><h2>Slajd 5.4</h2><p>Autor: Jules</p><p class="description">Opis slajdu 5.4</p></section>
+					<section class="bg-5-5"><h2>Slajd 5.5</h2><p>Autor: Jules</p><p class="description">Opis slajdu 5.5</p></section>
+					<section class="bg-5-6"><h2>Slajd 5.6</h2><p>Autor: Jules</p><p class="description">Opis slajdu 5.6</p></section>
+					<section class="bg-5-7"><h2>Slajd 5.7</h2><p>Autor: Jules</p><p class="description">Opis slajdu 5.7</p></section>
+					<section class="bg-5-8"><h2>Slajd 5.8</h2><p>Autor: Jules</p><p class="description">Opis slajdu 5.8</p></section>
+					<section class="bg-5-9"><h2>Slajd 5.9</h2><p>Autor: Jules</p><p class="description">Opis slajdu 5.9</p></section>
+				</section>
+				<section>
+					<section class="bg-6-1"><h2>Slajd 6.1</h2><p>Autor: Jules</p><p class="description">Opis slajdu 6.1</p></section>
+					<section class="bg-6-2"><h2>Slajd 6.2</h2><p>Autor: Jules</p><p class="description">Opis slajdu 6.2</p></section>
+					<section class="bg-6-3"><h2>Slajd 6.3</h2><p>Autor: Jules</p><p class="description">Opis slajdu 6.3</p></section>
+					<section class="bg-6-4"><h2>Slajd 6.4</h2><p>Autor: Jules</p><p class="description">Opis slajdu 6.4</p></section>
+					<section class="bg-6-5"><h2>Slajd 6.5</h2><p>Autor: Jules</p><p class="description">Opis slajdu 6.5</p></section>
+					<section class="bg-6-6"><h2>Slajd 6.6</h2><p>Autor: Jules</p><p class="description">Opis slajdu 6.6</p></section>
+					<section class="bg-6-7"><h2>Slajd 6.7</h2><p>Autor: Jules</p><p class="description">Opis slajdu 6.7</p></section>
+					<section class="bg-6-8"><h2>Slajd 6.8</h2><p>Autor: Jules</p><p class="description">Opis slajdu 6.8</p></section>
+					<section class="bg-6-9"><h2>Slajd 6.9</h2><p>Autor: Jules</p><p class="description">Opis slajdu 6.9</p></section>
+				</section>
+				<section>
+					<section class="bg-7-1"><h2>Slajd 7.1</h2><p>Autor: Jules</p><p class="description">Opis slajdu 7.1</p></section>
+					<section class="bg-7-2"><h2>Slajd 7.2</h2><p>Autor: Jules</p><p class="description">Opis slajdu 7.2</p></section>
+					<section class="bg-7-3"><h2>Slajd 7.3</h2><p>Autor: Jules</p><p class="description">Opis slajdu 7.3</p></section>
+					<section class="bg-7-4"><h2>Slajd 7.4</h2><p>Autor: Jules</p><p class="description">Opis slajdu 7.4</p></section>
+					<section class="bg-7-5"><h2>Slajd 7.5</h2><p>Autor: Jules</p><p class="description">Opis slajdu 7.5</p></section>
+					<section class="bg-7-6"><h2>Slajd 7.6</h2><p>Autor: Jules</p><p class="description">Opis slajdu 7.6</p></section>
+					<section class="bg-7-7"><h2>Slajd 7.7</h2><p>Autor: Jules</p><p class="description">Opis slajdu 7.7</p></section>
+					<section class="bg-7-8"><h2>Slajd 7.8</h2><p>Autor: Jules</p><p class="description">Opis slajdu 7.8</p></section>
+					<section class="bg-7-9"><h2>Slajd 7.9</h2><p>Autor: Jules</p><p class="description">Opis slajdu 7.9</p></section>
+				</section>
+				<section>
+					<section class="bg-8-1"><h2>Slajd 8.1</h2><p>Autor: Jules</p><p class="description">Opis slajdu 8.1</p></section>
+					<section class="bg-8-2"><h2>Slajd 8.2</h2><p>Autor: Jules</p><p class="description">Opis slajdu 8.2</p></section>
+					<section class="bg-8-3"><h2>Slajd 8.3</h2><p>Autor: Jules</p><p class="description">Opis slajdu 8.3</p></section>
+					<section class="bg-8-4"><h2>Slajd 8.4</h2><p>Autor: Jules</p><p class="description">Opis slajdu 8.4</p></section>
+					<section class="bg-8-5"><h2>Slajd 8.5</h2><p>Autor: Jules</p><p class="description">Opis slajdu 8.5</p></section>
+					<section class="bg-8-6"><h2>Slajd 8.6</h2><p>Autor: Jules</p><p class="description">Opis slajdu 8.6</p></section>
+					<section class="bg-8-7"><h2>Slajd 8.7</h2><p>Autor: Jules</p><p class="description">Opis slajdu 8.7</p></section>
+					<section class="bg-8-8"><h2>Slajd 8.8</h2><p>Autor: Jules</p><p class="description">Opis slajdu 8.8</p></section>
+					<section class="bg-8-9"><h2>Slajd 8.9</h2><p>Autor: Jules</p><p class="description">Opis slajdu 8.9</p></section>
+				</section>
+				<section>
+					<section class="bg-9-1"><h2>Slajd 9.1</h2><p>Autor: Jules</p><p class="description">Opis slajdu 9.1</p></section>
+					<section class="bg-9-2"><h2>Slajd 9.2</h2><p>Autor: Jules</p><p class="description">Opis slajdu 9.2</p></section>
+					<section class="bg-9-3"><h2>Slajd 9.3</h2><p>Autor: Jules</p><p class="description">Opis slajdu 9.3</p></section>
+					<section class="bg-9-4"><h2>Slajd 9.4</h2><p>Autor: Jules</p><p class="description">Opis slajdu 9.4</p></section>
+					<section class="bg-9-5"><h2>Slajd 9.5</h2><p>Autor: Jules</p><p class="description">Opis slajdu 9.5</p></section>
+					<section class="bg-9-6"><h2>Slajd 9.6</h2><p>Autor: Jules</p><p class="description">Opis slajdu 9.6</p></section>
+					<section class="bg-9-7"><h2>Slajd 9.7</h2><p>Autor: Jules</p><p class="description">Opis slajdu 9.7</p></section>
+					<section class="bg-9-8"><h2>Slajd 9.8</h2><p>Autor: Jules</p><p class="description">Opis slajdu 9.8</p></section>
+					<section class="bg-9-9"><h2>Slajd 9.9</h2><p>Autor: Jules</p><p class="description">Opis slajdu 9.9</p></section>
+				</section>
+			</div>
+		</div>
+		<script src="https://cdn.jsdelivr.net/npm/reveal.js@5.2.1/dist/reveal.js"></script>
+		<script>
+			Reveal.initialize({
+				hash: true,
+				controls: true,
+				progress: true,
+				center: true,
+				transition: 'convex',
+				backgroundTransition: 'fade',
+				touch: true,
+				loop: true
+			});
+		</script>
+	</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,99 @@
+.reveal .slides .description {
+	font-size: 0.6em;
+	position: absolute;
+	bottom: 20px;
+	left: 50%;
+	transform: translateX(-50%);
+	width: 90%;
+	text-align: center;
+}
+
+.reveal .slides section.bg-1-1 { background-color: #FFADAD; }
+.reveal .slides section.bg-1-2 { background-color: #FFD6A5; }
+.reveal .slides section.bg-1-3 { background-color: #FDFFB6; }
+.reveal .slides section.bg-1-4 { background-color: #CAFFBF; }
+.reveal .slides section.bg-1-5 { background-color: #9BF6FF; }
+.reveal .slides section.bg-1-6 { background-color: #A0C4FF; }
+.reveal .slides section.bg-1-7 { background-color: #BDB2FF; }
+.reveal .slides section.bg-1-8 { background-color: #FFC6FF; }
+.reveal .slides section.bg-1-9 { background-color: #FFFFFC; }
+
+.reveal .slides section.bg-2-1 { background-color: #FFC6FF; }
+.reveal .slides section.bg-2-2 { background-color: #BDB2FF; }
+.reveal .slides section.bg-2-3 { background-color: #A0C4FF; }
+.reveal .slides section.bg-2-4 { background-color: #9BF6FF; }
+.reveal .slides section.bg-2-5 { background-color: #CAFFBF; }
+.reveal .slides section.bg-2-6 { background-color: #FDFFB6; }
+.reveal .slides section.bg-2-7 { background-color: #FFD6A5; }
+.reveal .slides section.bg-2-8 { background-color: #FFADAD; }
+.reveal .slides section.bg-2-9 { background-color: #EAE4E9; }
+
+.reveal .slides section.bg-3-1 { background-color: #FFD6A5; }
+.reveal .slides section.bg-3-2 { background-color: #FDFFB6; }
+.reveal .slides section.bg-3-3 { background-color: #CAFFBF; }
+.reveal .slides section.bg-3-4 { background-color: #9BF6FF; }
+.reveal .slides section.bg-3-5 { background-color: #A0C4FF; }
+.reveal .slides section.bg-3-6 { background-color: #BDB2FF; }
+.reveal .slides section.bg-3-7 { background-color: #FFC6FF; }
+.reveal .slides section.bg-3-8 { background-color: #FFADAD; }
+.reveal .slides section.bg-3-9 { background-color: #FFF1E6; }
+
+.reveal .slides section.bg-4-1 { background-color: #CAFFBF; }
+.reveal .slides section.bg-4-2 { background-color: #9BF6FF; }
+.reveal .slides section.bg-4-3 { background-color: #A0C4FF; }
+.reveal .slides section.bg-4-4 { background-color: #BDB2FF; }
+.reveal .slides section.bg-4-5 { background-color: #FFC6FF; }
+.reveal .slides section.bg-4-6 { background-color: #FFADAD; }
+.reveal .slides section.bg-4-7 { background-color: #FFD6A5; }
+.reveal .slides section.bg-4-8 { background-color: #FDFFB6; }
+.reveal .slides section.bg-4-9 { background-color: #F0EFEB; }
+
+.reveal .slides section.bg-5-1 { background-color: #A0C4FF; }
+.reveal .slides section.bg-5-2 { background-color: #BDB2FF; }
+.reveal .slides section.bg-5-3 { background-color: #FFC6FF; }
+.reveal .slides section.bg-5-4 { background-color: #FFADAD; }
+.reveal .slides section.bg-5-5 { background-color: #FFD6A5; }
+.reveal .slides section.bg-5-6 { background-color: #FDFFB6; }
+.reveal .slides section.bg-5-7 { background-color: #CAFFBF; }
+.reveal .slides section.bg-5-8 { background-color: #9BF6FF; }
+.reveal .slides section.bg-5-9 { background-color: #E1EFE6; }
+
+.reveal .slides section.bg-6-1 { background-color: #FFC6FF; }
+.reveal .slides section.bg-6-2 { background-color: #FFADAD; }
+.reveal .slides section.bg-6-3 { background-color: #FFD6A5; }
+.reveal .slides section.bg-6-4 { background-color: #FDFFB6; }
+.reveal .slides section.bg-6-5 { background-color: #CAFFBF; }
+.reveal .slides section.bg-6-6 { background-color: #9BF6FF; }
+.reveal .slides section.bg-6-7 { background-color: #A0C4FF; }
+.reveal .slides section.bg-6-8 { background-color: #BDB2FF; }
+.reveal .slides section.bg-6-9 { background-color: #F4E1E1; }
+
+.reveal .slides section.bg-7-1 { background-color: #FFADAD; }
+.reveal .slides section.bg-7-2 { background-color: #FFD6A5; }
+.reveal .slides section.bg-7-3 { background-color: #FDFFB6; }
+.reveal .slides section.bg-7-4 { background-color: #CAFFBF; }
+.reveal .slides section.bg-7-5 { background-color: #9BF6FF; }
+.reveal .slides section.bg-7-6 { background-color: #A0C4FF; }
+.reveal .slides section.bg-7-7 { background-color: #BDB2FF; }
+.reveal .slides section.bg-7-8 { background-color: #FFC6FF; }
+.reveal .slides section.bg-7-9 { background-color: #E6E6FA; }
+
+.reveal .slides section.bg-8-1 { background-color: #BDB2FF; }
+.reveal .slides section.bg-8-2 { background-color: #A0C4FF; }
+.reveal .slides section.bg-8-3 { background-color: #9BF6FF; }
+.reveal .slides section.bg-8-4 { background-color: #CAFFBF; }
+.reveal .slides section.bg-8-5 { background-color: #FDFFB6; }
+.reveal .slides section.bg-8-6 { background-color: #FFD6A5; }
+.reveal .slides section.bg-8-7 { background-color: #FFADAD; }
+.reveal .slides section.bg-8-8 { background-color: #FFC6FF; }
+.reveal .slides section.bg-8-9 { background-color: #FAFAD2; }
+
+.reveal .slides section.bg-9-1 { background-color: #9BF6FF; }
+.reveal .slides section.bg-9-2 { background-color: #CAFFBF; }
+.reveal .slides section.bg-9-3 { background-color: #FDFFB6; }
+.reveal .slides section.bg-9-4 { background-color: #FFD6A5; }
+.reveal .slides section.bg-9-5 { background-color: #FFADAD; }
+.reveal .slides section.bg-9-6 { background-color: #FFC6FF; }
+.reveal .slides section.bg-9-7 { background-color: #BDB2FF; }
+.reveal .slides section.bg-9-8 { background-color: #A0C4FF; }
+.reveal .slides section.bg-9-9 { background-color: #F5F5DC; }


### PR DESCRIPTION
This commit introduces a 9x9 grid presentation prototype using Reveal.js.

- Creates an `index.html` file with the 9x9 slide structure.
- Creates a `style.css` file with custom styles for different slide backgrounds and content layout.
- Each slide includes a title, author, and description.
- Initializes Reveal.js with custom settings for transitions and controls to enhance user experience.