### PR TITLE
Fix TopBar layout, refactor Preloader, and update Share button

### DIFF
--- a/components/Preloader.tsx
+++ b/components/Preloader.tsx
@@ -50,7 +50,9 @@ const Preloader: React.FC = () => {
           exit={{ opacity: 0 }}
           transition={{ duration: 0.5 }}
         >
+          {/* Kontener ikony: wycentrowany absolutnie, aby uniknąć wpływu innych elementów */}
           <motion.div
+            className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2" // Użycie klas do absolutnego centrowania
             initial={{ scale: 1, opacity: 0.9 }}
             animate={{
               scale: [1, 1.03, 1],
@@ -65,15 +67,16 @@ const Preloader: React.FC = () => {
             <Image
               src="/icons/icon-512x512.png"
               alt="Ting Tong Logo"
-              width={192}
-              height={192}
+              width={192} // Stały rozmiar
+              height={192} // Stały rozmiar
               className="w-48 h-48"
               priority
             />
           </motion.div>
 
+          {/* Kontener wyboru języka: pojawia się po ikonie */}
           <motion.div
-            className="text-center mt-12"
+            className="text-center"
             initial={{ y: 50, opacity: 0 }}
             animate={{ y: 0, opacity: 1 }}
             transition={{ duration: 1, delay: 0.5, ease: 'easeOut' }}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import React, { useState } from 'react';
-import { Heart, MessageSquare, Rat, FileQuestion } from 'lucide-react';
-import { PiShareFat } from 'react-icons/pi';
+import { Heart, MessageSquare, Rat, FileQuestion, Share } from 'lucide-react';
 import { useToast } from '@/context/ToastContext';
 import { useUser } from '@/context/UserContext';
 import { useTranslation } from '@/context/LanguageContext';
@@ -123,7 +122,7 @@ const Sidebar: React.FC<SidebarProps> = ({
       </button>
 
       <button onClick={handleShare} className="flex flex-col items-center gap-0.5 text-white text-xs font-semibold">
-        <PiShareFat size={32} strokeWidth={1.4} className="stroke-white" style={{ filter: 'drop-shadow(0 0 3px rgba(0,0,0,0.5))' }}/>
+        <Share size={32} strokeWidth={1.4} className="stroke-white" style={{ filter: 'drop-shadow(0 0 3px rgba(0,0,0,0.5))' }}/>
         <span className="icon-label">{t('shareText') || 'Share'}</span>
       </button>
 

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -69,7 +69,7 @@ const TopBar = ({ openAccountPanel }: { openAccountPanel: () => void }) => {
       <div
         className="fixed top-0 left-0 right-0 z-40 flex items-center justify-between px-4 bg-black/50 backdrop-blur-md text-white border-b border-white/10"
         style={{
-          height: 'var(--topbar-height)',
+          height: 'var(--topbar-base-height)',
           paddingTop: 'var(--safe-area-top)',
         }}
       >

--- a/context/LanguageContext.tsx
+++ b/context/LanguageContext.tsx
@@ -16,7 +16,7 @@ const translations: Record<string, Record<string, string>> = {
         subscribeAriaLabel: 'Subskrybuj',
         shareTitle: 'Udostępnij ten film!',
         shareAriaLabel: 'Udostępnij',
-        shareText: 'Udostępnij',
+        shareText: 'Szeruj',
         infoTitle: 'Informacje',
         infoAriaLabel: 'Informacje',
         infoText: 'Info',


### PR DESCRIPTION
This commit addresses three separate issues:

1.  **Fix(TopBar):** Corrects a layout bug where padding was being applied twice. The `height` is now correctly set to `var(--topbar-base-height)`, and the `paddingTop` for the safe area is handled separately.

2.  **Refactor(Preloader):** Improves the preloader splash screen by ensuring the logo is perfectly centered using absolute positioning. This prevents layout shifts when the language selection appears and provides a smoother visual transition that matches the native PWA splash screen.

3.  **Feat(Sidebar):** Updates the share functionality.
    - The share icon has been replaced with the `Share` icon from `lucide-react` for consistency.
    - The Polish translation for "Share" has been changed from "Udostępnij" to "Szeruj".