### PR TITLE
Fix: Add isActive prop to SlideRenderer and HtmlContent

### DIFF
--- a/components/HtmlContent.tsx
+++ b/components/HtmlContent.tsx
@@ -8,9 +8,10 @@ interface HtmlContentProps {
   data: HtmlSlideData;
   username: string;
   onNavigate: (coordinates: { x: number; y: number }) => void;
+  isActive: boolean;
 }
 
-const HtmlContent: React.FC<HtmlContentProps> = ({ data }) => {
+const HtmlContent: React.FC<HtmlContentProps> = ({ data, isActive }) => {
   const sanitizedHtml = useMemo(() => {
     // Check if running in a browser environment before using DOMPurify
     if (typeof window !== 'undefined' && data.htmlContent) {

--- a/components/SlideRenderer.tsx
+++ b/components/SlideRenderer.tsx
@@ -7,12 +7,13 @@ import HtmlContent from './HtmlContent';
 
 interface SlideRendererProps {
   slide: Slide;
+  isActive: boolean;
 }
 
-const SlideRenderer: React.FC<SlideRendererProps> = ({ slide }) => {
+const SlideRenderer: React.FC<SlideRendererProps> = ({ slide, isActive }) => {
   return (
     <div className="h-full w-full">
-      <HtmlContent data={slide.data} username={slide.username} onNavigate={() => {}} />
+      <HtmlContent data={slide.data} username={slide.username} onNavigate={() => {}} isActive={isActive} />
     </div>
   );
 };


### PR DESCRIPTION
Resolves a compilation error where the `isActive` prop was passed to the `SlideRenderer` component from `app/page.tsx` but was not defined in its props interface.

This change adds the `isActive: boolean` prop to the `SlideRendererProps` interface in `components/SlideRenderer.tsx`.

Additionally, the prop is passed down to the `HtmlContent` component, so its interface, `HtmlContentProps`, has also been updated to include `isActive`.