### PR TITLE
Fix: Import useRef in VideoGridContext

### DIFF
--- a/context/VideoGridContext.tsx
+++ b/context/VideoGridContext.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { createContext, useEffect, useCallback, useMemo, ReactNode, useContext, useReducer } from 'react';
+import React, { createContext, useEffect, useCallback, useMemo, useRef, ReactNode, useContext, useReducer } from 'react';
 import { Grid, Slide } from '@/lib/types';
 import { useToast } from './ToastContext';
 export type ModalType = 'account' | 'comments' | 'info' | 'topbar' | null;


### PR DESCRIPTION
The build was failing because `useRef` was used in `context/VideoGridContext.tsx` without being imported from React. This change adds the missing import, resolving the build error.