### PR TITLE
Refactor PWA install prompt and fix logout button

### DIFF
--- a/components/AccountPanel.tsx
+++ b/components/AccountPanel.tsx
@@ -6,7 +6,10 @@ import ProfileTab from './ProfileTab';
 import PasswordTab from './PasswordTab';
 import DeleteTab from './DeleteTab';
 import { useTranslation } from '@/context/LanguageContext';
-import { X } from 'lucide-react';
+import { X, LogOut } from 'lucide-react';
+import { useUser } from '@/context/UserContext';
+import { useToast } from '@/context/ToastContext';
+import { Button } from './ui/button';
 
 interface AccountPanelProps {
   onClose: () => void;
@@ -17,10 +20,18 @@ type Tab = 'profile' | 'password' | 'delete';
 const AccountPanel: React.FC<AccountPanelProps> = ({ onClose }) => {
   const [activeTab, setActiveTab] = useState<Tab>('profile');
   const { t } = useTranslation();
+  const { logout } = useUser();
+  const { addToast } = useToast();
 
   const handleTabClick = (tab: Tab) => {
       setActiveTab(tab);
   }
+
+  const handleLogout = async () => {
+    await logout();
+    addToast(t('logoutSuccess'), 'success');
+    onClose();
+  };
 
   return (
     <motion.div
@@ -58,6 +69,16 @@ const AccountPanel: React.FC<AccountPanelProps> = ({ onClose }) => {
             {activeTab === 'profile' && <ProfileTab onClose={onClose} />}
             {activeTab === 'password' && <PasswordTab />}
             {activeTab === 'delete' && <DeleteTab />}
+        </div>
+
+        <div className="flex-shrink-0 p-4 bg-black/20 border-t border-white/10">
+            <Button
+                onClick={handleLogout}
+                className="w-full bg-red-600 hover:bg-red-700 text-white font-bold py-2 px-4 rounded-lg flex items-center justify-center space-x-2"
+            >
+                <LogOut size={18} />
+                <span>{t('logout')}</span>
+            </Button>
         </div>
       </motion.div>
     </motion.div>

--- a/components/PWAInstallPrompt.tsx
+++ b/components/PWAInstallPrompt.tsx
@@ -7,86 +7,57 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslation } from '@/context/LanguageContext';
 
 const PWAInstallPrompt = () => {
-    // ... (stary kod)
-    const [isDesktop, setIsDesktop] = useState(false);
-    const [installPrompt, setInstallPrompt] = useState<any>(null);
-    const [isStandalone, setIsStandalone] = useState(false);
-    const [isIOS, setIsIOS] = useState(false);
-    const [showInstructions, setShowInstructions] = useState(false);
-    const { t } = useTranslation();
+  const [installPrompt, setInstallPrompt] = useState<any>(null);
+  const [isStandalone, setIsStandalone] = useState(false);
+  const [isIOS, setIsIOS] = useState(false);
+  const [showInstructions, setShowInstructions] = useState(false);
+  const { t } = useTranslation();
 
-    useEffect(() => {
-        // ... (stary kod)
-        setIsDesktop(window.innerWidth > 768); // Ustawienie isDesktop dla ekranów > 768px
-        if (window.matchMedia('(display-mode: standalone)').matches) {
-          setIsStandalone(true);
-        }
-
-        const userAgent = window.navigator.userAgent;
-        if (/iPhone|iPad|iPod/i.test(userAgent) && !window.matchMedia('(display-mode: standalone)').matches) {
-          setIsIOS(true);
-        }
-
-        const handleBeforeInstallPrompt = (e: Event) => {
-          e.preventDefault();
-          setInstallPrompt(e);
-        };
-
-        window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
-
-        return () => {
-          window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
-        };
-    }, []);
-
-    const handleInstallClick = () => {
-      if (installPrompt) {
-        installPrompt.prompt();
-        installPrompt.userChoice.then((choiceResult: { outcome: string }) => {
-          if (choiceResult.outcome === 'accepted') {
-            console.log('User accepted the install prompt');
-          } else {
-            console.log('User dismissed the install prompt');
-          }
-          setInstallPrompt(null);
-        });
-      } else if (isIOS) {
-        setShowInstructions(true);
-      }
-    };
-
-    const handleCloseInstructions = () => {
-      setShowInstructions(false);
-    };
-
-    // Show desktop modal only in production
-    if (process.env.NODE_ENV === 'production' && isDesktop && !isStandalone) {
-        return (
-            <motion.div
-                className="fixed inset-0 bg-black/90 z-50 flex items-center justify-center p-4 text-center"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-            >
-                <div className="bg-zinc-800 text-white rounded-lg p-8 shadow-xl">
-                    <h3 className="text-2xl font-bold mb-4">Pobierz aplikację na telefon</h3>
-                    <p className="mb-6">
-                        Wersja na komputery stacjonarne nie obsługuje pełnego doświadczenia.
-                        Proszę zeskanować kod QR lub wejść na naszą stronę na telefonie,
-                        aby pobrać aplikację i odkryć świat tingotong!
-                    </p>
-                    {/* Można dodać tutaj obrazek z kodem QR */}
-                    <div className="w-32 h-32 bg-white mx-auto">
-                        {/* Placeholder for QR Code */}
-                    </div>
-                </div>
-            </motion.div>
-        );
+  useEffect(() => {
+    if (window.matchMedia('(display-mode: standalone)').matches) {
+      setIsStandalone(true);
     }
 
-    if (isStandalone || (!installPrompt && !isIOS)) {
-        return null;
+    const userAgent = window.navigator.userAgent;
+    if (/iPhone|iPad|iPod/i.test(userAgent) && !window.matchMedia('(display-mode: standalone)').matches) {
+      setIsIOS(true);
     }
+
+    const handleBeforeInstallPrompt = (e: Event) => {
+      e.preventDefault();
+      setInstallPrompt(e);
+    };
+
+    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+
+    return () => {
+      window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+    };
+  }, []);
+
+  const handleInstallClick = () => {
+    if (installPrompt) {
+      installPrompt.prompt();
+      installPrompt.userChoice.then((choiceResult: { outcome: string }) => {
+        if (choiceResult.outcome === 'accepted') {
+          console.log('User accepted the install prompt');
+        } else {
+          console.log('User dismissed the install prompt');
+        }
+        setInstallPrompt(null);
+      });
+    } else if (isIOS) {
+      setShowInstructions(true);
+    }
+  };
+
+  const handleCloseInstructions = () => {
+    setShowInstructions(false);
+  };
+
+  if (isStandalone || (!installPrompt && !isIOS)) {
+    return null;
+  }
 
   return (
     <AnimatePresence>

--- a/components/PwaDesktopModal.tsx
+++ b/components/PwaDesktopModal.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import React from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Button } from './ui/button';
+import { X } from 'lucide-react';
+import { useTranslation } from '@/context/LanguageContext';
+
+interface PwaDesktopModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const PwaDesktopModal: React.FC<PwaDesktopModalProps> = ({ isOpen, onClose }) => {
+  const { t } = useTranslation();
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          className="fixed inset-0 bg-black/90 z-50 flex items-center justify-center p-4 text-center"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          onClick={onClose}
+        >
+          <motion.div
+            className="bg-zinc-800 text-white rounded-lg p-8 shadow-xl max-w-sm w-full"
+            initial={{ scale: 0.9, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.9, opacity: 0 }}
+            transition={{ duration: 0.3 }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex justify-end mb-4">
+              <Button variant="ghost" size="icon" onClick={onClose}>
+                <X className="h-5 w-5" />
+              </Button>
+            </div>
+            <h3 className="text-2xl font-bold mb-4">Pobierz aplikację na telefon</h3>
+            <p className="mb-6">
+              Wersja na komputery stacjonarne nie obsługuje pełnego doświadczenia.
+              Proszę zeskanować kod QR lub wejść na naszą stronę na telefonie,
+              aby pobrać aplikację i odkryć świat tingotong!
+            </p>
+            <div className="w-32 h-32 bg-white mx-auto">
+              {/* Placeholder for QR Code */}
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};
+
+export default PwaDesktopModal;

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -12,6 +12,7 @@ import LoginForm from './LoginForm';
 import { useToast } from '@/context/ToastContext';
 import MenuIcon from './icons/MenuIcon';
 import BellIcon from './icons/BellIcon';
+import PwaDesktopModal from './PwaDesktopModal'; // Import nowego komponentu
 
 const TopBar = () => {
   const { user } = useUser();
@@ -21,6 +22,8 @@ const TopBar = () => {
   const [unreadCount, setUnreadCount] = useState(0);
   const [showNotifPanel, setShowNotifPanel] = useState(false);
   const [isLoginPanelOpen, setIsLoginPanelOpen] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(false); // Nowy stan
+  const [showPwaModal, setShowPwaModal] = useState(false); // Nowy stan
 
   useEffect(() => {
     const fetchNotifications = async () => {
@@ -37,6 +40,16 @@ const TopBar = () => {
       fetchNotifications();
     }
   }, [user]);
+
+  // Nowy useEffect do wykrywania desktopu
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+        setIsDesktop(window.innerWidth > 768);
+        const handleResize = () => setIsDesktop(window.innerWidth > 768);
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }
+  }, []);
 
   // --- Handlers for Logged-Out State ---
   const handleLoggedOutMenuClick = () => {
@@ -62,6 +75,10 @@ const TopBar = () => {
     }
   };
 
+  const handleShowPwaModal = () => {
+    setShowPwaModal(true);
+  };
+
   return (
     <>
       <div
@@ -84,7 +101,7 @@ const TopBar = () => {
             <div className="flex justify-center flex-1 text-center">
               <button
                 onClick={() => setIsLoginPanelOpen(panel => !panel)}
-                className="font-semibold text-md text-white transition-all duration-300 hover:text-pink-500 hover:scale-110 focus:outline-none focus:scale-110 focus:text-pink-500"
+                className="font-semibold text-sm text-white transition-all duration-300 hover:text-pink-500 hover:scale-110 focus:outline-none focus:scale-110 focus:text-pink-500"
               >
                 <span>{t('loggedOutText')}</span>
                 <span className='ml-2'>Ting Tong</span>
@@ -92,6 +109,12 @@ const TopBar = () => {
             </div>
 
             <div className="flex justify-end w-16">
+              {/* Nowy przycisk do pobierania PWA */}
+              {isDesktop && (
+                  <Button variant="ghost" size="icon" onClick={handleShowPwaModal} aria-label={t('installPwaAriaLabel')}>
+                      <span className="text-sm font-semibold">{t('installAppText')}</span>
+                  </Button>
+              )}
               <Button variant="ghost" size="icon" onClick={handleLoggedOutNotificationClick} aria-label={t('notificationAriaLabel')}>
                 <BellIcon className="w-6 h-6" />
               </Button>
@@ -121,6 +144,11 @@ const TopBar = () => {
             </div>
 
             <div className="flex justify-end">
+                {isDesktop && (
+                    <Button variant="ghost" size="icon" onClick={handleShowPwaModal} aria-label={t('installPwaAriaLabel')}>
+                        <span className="text-sm font-semibold">{t('installAppText')}</span>
+                    </Button>
+                )}
                 <div className="relative">
                     <Button variant="ghost" size="icon" onClick={handleLoggedInNotificationClick} aria-label={t('notificationAriaLabel')}>
                         <BellIcon className="w-6 h-6" />
@@ -153,6 +181,12 @@ const TopBar = () => {
           </motion.div>
         )}
       </AnimatePresence>
+
+      {/* Nowy modal dla PWA na desktopie */}
+      <PwaDesktopModal
+        isOpen={showPwaModal}
+        onClose={() => setShowPwaModal(false)}
+      />
     </>
   );
 };

--- a/context/LanguageContext.tsx
+++ b/context/LanguageContext.tsx
@@ -4,7 +4,7 @@ import React, { createContext, useState, useContext, ReactNode, useEffect } from
 
 const translations: Record<string, Record<string, string>> = {
     pl: {
-        loggedOutText: "Nie masz psychy?",
+        loggedOutText: "Nie masz psychy sie zalogowac",
         loggedInWelcome: 'Witaj, {name}',
         loading: 'Ładowanie...',
         selectLang: 'Wybierz Język',
@@ -139,10 +139,12 @@ const translations: Record<string, Record<string, string>> = {
         zoomInAriaLabel: 'Powiększ',
         saveAvatarAriaLabel: 'Zapisz nowy awatar',
         saveAvatarButton: 'Zapisz Awatar',
-        adminPanel: 'Panel Admina'
+        adminPanel: 'Panel Admina',
+        installPwaAriaLabel: 'Pobierz aplikację',
+        installAppText: 'Pobierz'
     },
     en: {
-        loggedOutText: "Don't have the guts?",
+        loggedOutText: "Don't have the guts to log in",
         loggedInWelcome: 'Welcome, {name}',
         loading: 'Loading...',
         selectLang: 'Select Language',
@@ -277,7 +279,9 @@ const translations: Record<string, Record<string, string>> = {
         zoomInAriaLabel: 'Zoom in',
         saveAvatarAriaLabel: 'Save new avatar',
         saveAvatarButton: 'Save Avatar',
-        adminPanel: 'Admin Panel'
+        adminPanel: 'Admin Panel',
+        installPwaAriaLabel: 'Download App',
+        installAppText: 'Download'
     }
 };
 


### PR DESCRIPTION
- Removes the desktop-blocking logic from the PWA install prompt.
- Introduces a new modal for desktop users to prompt them to install the app on their mobile devices.
- Adds a 'Download App' button to the TopBar, visible only on desktop.
- Fixes the broken logout button by adding it to the AccountPanel.
- Updates the text for logged-out users in the TopBar.