### PR TITLE
Fix layout issues with TopBar and PWA prompt

### DIFF
--- a/components/PWAInstallPrompt.tsx
+++ b/components/PWAInstallPrompt.tsx
@@ -90,6 +90,7 @@ const PWAInstallPrompt = () => {
             animate={{ y: 0, opacity: 1 }}
             exit={{ y: '100%', opacity: 0 }}
             transition={{ type: 'spring', stiffness: 400, damping: 40 }}
+            style={{ paddingBottom: 'var(--safe-area-bottom)' }}
           >
             <div className="flex w-full justify-between items-center mb-4">
               <h3 className="text-lg font-bold">Jak zainstalować aplikację</h3>
@@ -106,7 +107,10 @@ const PWAInstallPrompt = () => {
             </div>
           </motion.div>
         ) : (
-          <div className="absolute bottom-0 w-full bg-gray-800 text-white p-4 flex justify-between items-center z-50">
+          <div
+            className="w-full bg-gray-800 text-white p-4 flex justify-between items-center z-50"
+            style={{ paddingBottom: 'calc(1rem + var(--safe-area-bottom))' }}
+          >
             <div>
               <p className="font-bold">Zainstaluj aplikację!</p>
               <p>Uzyskaj pełne wrażenia. Zainstaluj naszą aplikację na swoim urządzeniu.</p>

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -65,7 +65,7 @@ const TopBar = () => {
   return (
     <>
       <div
-        className="relative z-[100] flex items-center justify-between px-1 bg-black/60 text-white backdrop-blur-sm border-b border-white/10"
+        className="relative z-40 flex items-center justify-between px-2 bg-black/60 text-white backdrop-blur-sm border-b border-white/10"
         style={{
           height: 'var(--topbar-height)',
         }}
@@ -75,22 +75,22 @@ const TopBar = () => {
           <>
             <div className="flex justify-start">
                 <Button variant="ghost" size="icon" onClick={handleLoggedOutMenuClick} aria-label={t('menuAriaLabel')}>
-                    <MenuIcon className="w-6 h-6" />
+                    <MenuIcon className="w-7 h-7" />
                 </Button>
             </div>
 
-            <div className="flex justify-center flex-1 text-center">
+            <div className="flex justify-center flex-1 text-center px-1">
               <button
                 onClick={() => setIsLoginPanelOpen(panel => !panel)}
                 className="font-semibold text-sm text-white transition-all duration-300 hover:scale-110 focus:outline-none focus:scale-110 whitespace-nowrap"
               >
-                <span>{t('loggedOutText')}</span>
+                <span className="mx-2">{t('loggedOutText')}</span>
               </button>
             </div>
 
             <div className="flex justify-end">
               <Button variant="ghost" size="icon" onClick={handleLoggedOutNotificationClick} aria-label={t('notificationAriaLabel')}>
-                <BellIcon className="w-6 h-6" />
+                <BellIcon className="w-7 h-7" />
               </Button>
             </div>
           </>
@@ -103,12 +103,12 @@ const TopBar = () => {
                         <Image
                             src={user.avatar}
                             alt={t('avatarAlt')}
-                            width={32}
-                            height={32}
+                            width={36}
+                            height={36}
                             className="rounded-full"
                         />
                     ) : (
-                        <div className="w-8 h-8 rounded-full bg-gray-300 dark:bg-zinc-700" />
+                        <div className="w-9 h-9 rounded-full bg-gray-300 dark:bg-zinc-700" />
                     )}
                 </Button>
             </div>
@@ -120,7 +120,7 @@ const TopBar = () => {
             <div className="flex justify-end">
                 <div className="relative">
                     <Button variant="ghost" size="icon" onClick={handleLoggedInNotificationClick} aria-label={t('notificationAriaLabel')}>
-                        <BellIcon className="w-6 h-6" />
+                        <BellIcon className="w-7 h-7" />
                         {unreadCount > 0 && (
                             <span className="absolute top-1 right-1 block h-2 w-2 rounded-full ring-2 ring-black bg-pink-500" />
                         )}


### PR DESCRIPTION
This commit addresses several layout issues:

- The TopBar now has a lower z-index to prevent it from overlapping with modals.
- The layout of the TopBar has been adjusted to provide more space for the central text and improve the placement of icons.
- The PWA install prompt now respects mobile safe areas, preventing it from being obscured by system navigation bars.
- The PWA install prompt's desktop layout has been fixed by removing absolute positioning, ensuring it is correctly positioned at the bottom of the simulated phone screen.