### PR TITLE
fix(sanitize): Resolve DOMPurify type mismatch with JSDOM window

### DIFF
--- a/lib/sanitize.ts
+++ b/lib/sanitize.ts
@@ -5,7 +5,7 @@ import { JSDOM } from 'jsdom';
 const window = new JSDOM('').window;
 
 // Create a DOMPurify instance from the JSDOM window
-const purify = DOMPurify(window as unknown as Window);
+const purify = DOMPurify(window as any);
 
 /**
  * Sanitizes an HTML string to prevent XSS attacks.


### PR DESCRIPTION
The build was failing due to a type mismatch when initializing DOMPurify with the JSDOM window object. The JSDOM window object is not fully compatible with the DOMPurify type definition.

This commit resolves the issue by casting the JSDOM window object to `any`, which bypasses the strict type-checking and allows the build to succeed.