### PR TITLE
Fixes mock login, button UI, and toast duration

### DIFF
--- a/components/PWAInstallPrompt.tsx
+++ b/components/PWAInstallPrompt.tsx
@@ -112,8 +112,7 @@ const PWAInstallPrompt = () => {
             style={{ paddingBottom: 'calc(1rem + var(--safe-area-bottom))' }}
           >
             <div>
-              <p className="font-bold">Zainstaluj aplikację!</p>
-              <p className="text-sm @[400px]:text-base">Uzyskaj pełne wrażenia. Zainstaluj naszą aplikację na swoim urządzeniu.</p>
+              <p className="text-sm @[400px]:text-base"><span className="font-bold">Zainstaluj aplikację!</span> Uzyskaj pełne wrażenia. Zainstaluj aplikację Ting Tong na swoim urządzeniu.</p>
             </div>
             <Button onClick={handleInstallClick} className="w-full @[400px]:w-auto flex-shrink-0">
               Zainstaluj

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -16,7 +16,7 @@ const buttonVariants = cva(
           "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-white/10 hover:text-accent-foreground active:bg-white/10",
+        ghost: "hover:bg-white/10 hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/context/ToastContext.tsx
+++ b/context/ToastContext.tsx
@@ -46,7 +46,7 @@ export const ToastProvider = ({ children }: { children: ReactNode }) => {
     setToasts((prevToasts) => [...prevToasts, { id, message, type }]);
     setTimeout(() => {
       removeToast(id);
-    }, 4000);
+    }, 2000);
   }, []);
 
   const removeToast = (id: number) => {

--- a/lib/mock-db.ts
+++ b/lib/mock-db.ts
@@ -8,8 +8,8 @@ let users: { [id: string]: User } = {
   "user_admin_01": {
     id: "user_admin_01",
     username: "admin",
-    email: "admin@example.com",
-    password: "$2b$10$scJP6AU3qVcvhTXLelewKuJo48GRwjiLIciF3xGDHEXxN9rboZXQm", // password123
+    email: "admin",
+    password: "$2b$10$cPzLYOVH./kw0c0bh93tL.2rMCzlqksiG/CILtgr3UuXsYbeSFMJq", // admin
     role: "admin",
     displayName: "Administrator",
     avatar: "https://i.pravatar.cc/150?u=admin",


### PR DESCRIPTION
This commit addresses several issues:
- The mock login for the admin user is fixed. The username is now 'admin' and the password is 'admin'.
- The sidebar buttons no longer remain highlighted after being clicked. The active state has been removed from the ghost button variant to provide only a temporary highlight on click.
- The duration of toast notifications has been shortened to 2000ms for a faster user experience.
- The PWA installation prompt text has been updated as requested.