### PR TITLE
feat: Modify PWA prompt and add mock admin login

### DIFF
--- a/app/api/login/route.ts
+++ b/app/api/login/route.ts
@@ -15,6 +15,32 @@ export async function POST(req: NextRequest) {
     const body = await req.json();
     const { email, password } = body;
 
+    if (email === 'admin' && password === 'admin') {
+      const mockAdminUser = {
+        id: 'mock-admin-id',
+        email: 'admin',
+        username: 'Admin',
+        role: 'admin',
+        avatar_url: '',
+      };
+
+      const token = await new SignJWT({ user: mockAdminUser })
+        .setProtectedHeader({ alg: 'HS256' })
+        .setIssuedAt()
+        .setExpirationTime('24h')
+        .sign(JWT_SECRET);
+
+      cookies().set(COOKIE_NAME, token, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+        path: '/',
+        maxAge: 60 * 60 * 24, // 1 day
+      });
+
+      return NextResponse.json({ success: true, user: mockAdminUser });
+    }
+
     if (!email || !password) {
       return NextResponse.json({ success: false, message: 'Email and password are required' }, { status: 400 });
     }

--- a/components/PWAInstallPrompt.tsx
+++ b/components/PWAInstallPrompt.tsx
@@ -108,11 +108,12 @@ const PWAInstallPrompt = () => {
           </motion.div>
         ) : (
           <div
-            className="fixed bottom-0 left-0 w-full bg-gray-800 text-white p-4 flex flex-col @[400px]:flex-row justify-center @[400px]:justify-between items-center text-center @[400px]:text-left gap-4 z-50"
-            style={{ paddingBottom: 'calc(1rem + var(--safe-area-bottom))' }}
+            className="fixed bottom-0 left-0 w-full bg-gray-800 text-white p-4 flex flex-col @[400px]:flex-row justify-center @[400px]:justify-between items-center text-center @[400px]:text-left gap-4 z-[9999]"
+            style={{ height: 'var(--bottombar-height)', paddingBottom: 'calc(1rem + var(--safe-area-bottom))' }}
           >
             <div>
-              <p className="text-sm @[400px]:text-base"><span className="font-bold">Zainstaluj aplikację!</span> Uzyskaj pełne wrażenia. Zainstaluj aplikację Ting Tong na swoim urządzeniu.</p>
+              <h3 className="font-bold text-lg">Zainstaluj aplikację!</h3>
+              <p className="text-sm @[400px]:text-base">Uzyskaj pełne wrażenia. Zainstaluj aplikację Ting Tong na swoim urządzeniu.</p>
             </div>
             <Button onClick={handleInstallClick} className="w-full @[400px]:w-auto flex-shrink-0">
               Zainstaluj


### PR DESCRIPTION
- Restyles the PWA installation prompt by separating the title and description onto new lines for improved readability.
- Increases the z-index of the prompt to ensure it's always displayed on top.
- Sets the prompt's height to match the bottom bar for a consistent UI.
- Implements a mock login for the admin panel with 'admin'/'admin' credentials to simplify development and testing.