### PR TITLE
Poprawa wyglądu prealoadera

### DIFF
--- a/components/Preloader.tsx
+++ b/components/Preloader.tsx
@@ -43,65 +43,59 @@ const Preloader: React.FC = () => {
     <AnimatePresence>
       {!isHiding && (
         <motion.div
-          className="fixed inset-0 bg-black z-[10000] flex flex-col items-center" // Usunięto justify-center
+          className="fixed inset-0 bg-black z-[10000] flex flex-col items-center justify-center p-4"
           initial={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: 0.5 }}
         >
-          {/* Kontener dla logo, który zajmuje elastyczną przestrzeń */}
-          <div className="flex-1 flex items-end justify-center w-full">
-            <motion.div
-              className="relative flex-shrink-0" // Zapewnia, że logo się nie skurczy
-              initial={{ scale: 1, opacity: 0.9 }}
-              animate={{
-                scale: [1, 1.03, 1],
-                opacity: [0.9, 1, 0.9],
-              }}
-              transition={{
-                duration: 2.5,
-                repeat: Infinity,
-                ease: 'easeInOut',
-              }}
-            >
-              <Image
-                src="/icons/icon-512x512.png"
-                alt="Ting Tong Logo"
-                width={192}
-                height={192}
-                className="w-48 h-48"
-                priority
-              />
-            </motion.div>
-          </div>
-          {/* Kontener dla zawartości (wybór języka), który zajmuje resztę miejsca */}
-          <div className="flex-1 flex flex-col items-center justify-start w-full">
-            <motion.div
-              className="text-center w-full"
-              initial={{ y: 50, opacity: 0 }}
-              animate={{ y: 0, opacity: 1 }}
-              transition={{ duration: 1, delay: 0.5, ease: 'easeOut' }}
-            >
-              <h2 className="text-xl font-semibold text-white mb-6">{t('selectLang')}</h2>
-              <div className="flex flex-col gap-4 w-64">
-                <motion.button
-                  onClick={() => handleLangSelect('pl')}
-                  className="bg-white/5 border border-white/20 hover:bg-white/10 text-base py-6 rounded-md"
-                  whileTap={{ scale: 0.95 }}
-                  transition={{ duration: 0.2 }}
-                >
-                  {t('polish')}
-                </motion.button>
-                <motion.button
-                  onClick={() => handleLangSelect('en')}
-                  className="bg-white/5 border border-white/20 hover:bg-white/10 text-base py-6 rounded-md"
-                  whileTap={{ scale: 0.95 }}
-                  transition={{ duration: 0.2 }}
-                >
-                  {t('english')}
-                </motion.button>
-              </div>
-            </motion.div>
-          </div>
+          <motion.div
+            className="relative mb-12"
+            initial={{ scale: 1, opacity: 0.9 }}
+            animate={{
+              scale: [1, 1.03, 1],
+              opacity: [0.9, 1, 0.9],
+            }}
+            transition={{
+              duration: 2.5,
+              repeat: Infinity,
+              ease: 'easeInOut',
+            }}
+          >
+            <Image
+              src="/icons/icon-512x512.png"
+              alt="Ting Tong Logo"
+              width={192}
+              height={192}
+              priority
+            />
+          </motion.div>
+
+          <motion.div
+            className="text-center w-full flex flex-col items-center"
+            initial={{ y: 50, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            transition={{ duration: 1, delay: 0.5, ease: 'easeOut' }}
+          >
+            <h2 className="text-xl font-semibold text-white mb-6">{t('selectLang')}</h2>
+            <div className="flex flex-col gap-4 w-full max-w-sm">
+              <motion.button
+                onClick={() => handleLangSelect('pl')}
+                className="bg-white/5 border border-white/20 hover:bg-white/10 text-base py-6 rounded-md"
+                whileTap={{ scale: 0.95 }}
+                transition={{ duration: 0.2 }}
+              >
+                {t('polish')}
+              </motion.button>
+              <motion.button
+                onClick={() => handleLangSelect('en')}
+                className="bg-white/5 border border-white/20 hover:bg-white/10 text-base py-6 rounded-md"
+                whileTap={{ scale: 0.95 }}
+                transition={{ duration: 0.2 }}
+              >
+                {t('english')}
+              </motion.button>
+            </div>
+          </motion.div>
         </motion.div>
       )}
     </AnimatePresence>


### PR DESCRIPTION
Poprawia wygląd prealoadera, aby spełnić wymagania użytkownika.

- Logo jest teraz idealnie wyśrodkowane w pionie i poziomie.
- Rozmiar logo jest ustawiony na 192x192px bez zniekształceń.
- Menu wyboru języka znajduje się pod logo i jest estetycznie dopasowane.

Zmiany zostały wprowadzone w komponencie `components/Preloader.tsx` poprzez uproszczenie układu flexbox i dostosowanie klas Tailwind CSS.