### PR TITLE
feat: Display sidebar and bottom bar on specific slides

### DIFF
--- a/components/VideoPlayer.tsx
+++ b/components/VideoPlayer.tsx
@@ -23,6 +23,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({ slide, isActive }) => {
   const [videoSrc, setVideoSrc] = useState(slide.data?.hlsUrl || slide.data?.mp4Url);
   const [areBarsVisible, setAreBarsVisible] = useState(true);
   const isHls = videoSrc?.endsWith('.m3u8');
+  const shouldShowBars = slide.y === 0 || slide.y === 2;
 
   useEffect(() => {
     if (isActive) {
@@ -91,7 +92,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({ slide, isActive }) => {
       />
 
       <AnimatePresence>
-        {isActive && areBarsVisible && (
+        {isActive && areBarsVisible && shouldShowBars && (
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}


### PR DESCRIPTION
The user requested to show the sidebar and bottom bar only on slides with index 0 and 2.

- In `VideoPlayer.tsx`, added a condition to render the `Sidebar` and `BottomBar` only when the slide's `y` coordinate is 0 or 2.
- The existing logic in `HtmlContent.tsx` already correctly showed the `Sidebar` on slides 0 and 2, so no changes were needed there after reverting an incorrect modification.

This ensures the UI components appear consistently based on the slide index as requested.