### PR TITLE
feat(preloader): update preloader layout to match prototype

### DIFF
--- a/components/Preloader.tsx
+++ b/components/Preloader.tsx
@@ -9,8 +9,7 @@ import Image from 'next/image';
 const Preloader: React.FC = () => {
   const { t, selectInitialLang, isLangSelected } = useTranslation();
   const [isHiding, setIsHiding] = useState(false);
-  const [hasShown, setHasShown] = useState(false);
-
+  const [contentVisible, setContentVisible] = useState(false);
 
   const handleLangSelect = (lang: 'pl' | 'en') => {
     const videos = document.querySelectorAll('video');
@@ -35,66 +34,85 @@ const Preloader: React.FC = () => {
     }, 300);
   };
 
-  if (hasShown) {
-    return null;
-  }
+  useEffect(() => {
+    const timer = setTimeout(() => setContentVisible(true), 500);
+    return () => clearTimeout(timer);
+  }, []);
+
+  // If language is already selected, we don't need the preloader.
+  // This prevents it from flashing on hot-reloads during development.
+  useEffect(() => {
+      if (isLangSelected) {
+          setIsHiding(true);
+      }
+  }, [isLangSelected]);
 
   return (
     <AnimatePresence>
       {!isHiding && (
         <motion.div
-          className="fixed inset-0 bg-black z-[10000] flex flex-col p-4"
+          className="fixed inset-0 bg-black z-[10000] overflow-hidden"
           initial={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: 0.5, delay: 0.3 }}
         >
+          {/* Icon Container - Centered */}
           <motion.div
-            className="flex-grow flex items-center justify-center"
-            initial={{ opacity: 0, y: 50 }}
-            animate={{ opacity: 1, y: 0 }}
+            className="absolute top-1/2 left-1/2 w-[150px] h-[150px] -translate-x-1/2 -translate-y-1/2"
+            initial={{ opacity: 0, scale: 0.9 }}
+            animate={{ opacity: 1, scale: 1 }}
             transition={{ duration: 0.5, ease: 'easeOut' }}
           >
-            <div className="flex flex-col items-center text-center">
-              <motion.div
-                className="relative"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                transition={{ duration: 1, ease: 'easeInOut' }}
-              >
-                <Image
-                  src="/icons/icon-512x512.png"
-                  alt="Ting Tong Logo"
-                  width={150}
-                  height={150}
-                  priority
-                />
-              </motion.div>
-              <motion.div
-                className="text-center w-full flex flex-col items-center"
-                initial={{ y: 20, opacity: 0 }}
-                animate={{ y: 0, opacity: 1 }}
-                transition={{ duration: 1, delay: 0.5, ease: 'easeOut' }}
-              >
-            <h2 className="text-xl font-semibold text-white mb-6">{t('selectLang')}</h2>
-            <div className="flex flex-col gap-4 w-full max-w-sm">
-              <motion.button
-                onClick={() => handleLangSelect('pl')}
-                className="bg-white/5 border border-white/20 hover:bg-white/10 text-base py-6 rounded-md"
-                whileTap={{ scale: 0.95 }}
-                transition={{ duration: 0.2 }}
-              >
-                {t('polish')}
-              </motion.button>
-              <motion.button
-                onClick={() => handleLangSelect('en')}
-                className="bg-white/5 border border-white/20 hover:bg-white/10 text-base py-6 rounded-md"
-                whileTap={{ scale: 0.95 }}
-                transition={{ duration: 0.2 }}
-              >
-                {t('english')}
-              </motion.button>
-            </div>
-              </motion.div>
+            <motion.div
+              className="w-full h-full"
+              animate={{
+                scale: [1, 1.03, 1],
+                opacity: [0.9, 1, 0.9],
+              }}
+              transition={{
+                duration: 2.5,
+                ease: "easeInOut",
+                repeat: Infinity,
+              }}
+            >
+              <Image
+                src="/icons/icon-512x512.png"
+                alt="Ting Tong Logo"
+                width={150}
+                height={150}
+                priority
+              />
+            </motion.div>
+          </motion.div>
+
+          {/* Content Container - Below Icon */}
+          <motion.div
+            className="absolute left-0 right-0 bottom-0 flex flex-col items-center justify-center p-4"
+            style={{ top: 'calc(50% + 75px)' }} // 75px is half of the icon's height
+            initial={{ opacity: 0, y: '100%' }}
+            animate={{ opacity: contentVisible ? 1 : 0, y: contentVisible ? 0 : '100%' }}
+            transition={{ duration: 1, ease: [0.68, -0.55, 0.27, 1.55] }}
+          >
+            <div className="text-center w-full flex flex-col items-center">
+              <h2 className="text-xl font-semibold text-white mb-6">{t('selectLang')}</h2>
+              <div className="flex flex-col gap-4 w-full max-w-sm">
+                <motion.button
+                  onClick={() => handleLangSelect('pl')}
+                  className="bg-white/5 border border-white/20 hover:bg-white/10 text-base py-6 rounded-md"
+                  whileTap={{ scale: 0.95 }}
+                  transition={{ duration: 0.2 }}
+                >
+                  {t('polish')}
+                </motion.button>
+                <motion.button
+                  onClick={() => handleLangSelect('en')}
+                  className="bg-white/5 border border-white/20 hover:bg-white/10 text-base py-6 rounded-md"
+                  whileTap={{ scale: 0.95 }}
+                  transition={{ duration: 0.2 }}
+                >
+                  {t('english')}
+                </motion.button>
+              </div>
             </div>
           </motion.div>
         </motion.div>


### PR DESCRIPTION
Refactored the Preloader.tsx component to align with the layout specified in prototyp.txt.

- The splash screen icon is now centered vertically and horizontally on the screen using absolute positioning.
- The language selection UI is positioned in the space below the centered icon, filling the bottom half of the screen.
- Replaced the previous flexbox layout with a two-container structure to allow for independent positioning of the icon and the language selection content.
- Implemented Framer Motion animations for a smooth appearance, including a pulse-glow effect for the icon and a slide-in transition for the language selection buttons.