### PR TITLE
fix(frontend): Correct React Fragment syntax in page.tsx

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -190,7 +190,7 @@ export default function Home() {
   );
 
   return (
-    <Fragment>
+    <>
       <GlobalVideoPlayer />
       {appContent}
       <AnimatePresence>


### PR DESCRIPTION
Resolves a compilation error caused by inconsistent React Fragment syntax. The component was using `<Fragment>` as an opening tag and `</>` as a closing tag.

This change replaces the explicit `<Fragment>` tag with the shorthand `<>` to match the closing tag, ensuring valid JSX syntax.