### PR TITLE
Fix cascading build errors and dependency issues

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -42,8 +42,6 @@ export default function Home() {
   const {
     state: { columns, activeColumnIndex, activeSlideId, error, activeModal, isNavigating },
     isAnyModalOpen,
-    columnKeys,
-    isLoading,
     setActiveModal,
     activeSlide,
     handleNavigation,
@@ -123,6 +121,7 @@ export default function Home() {
               <List
                 ref={listRef}
                 height={appHeight}
+                width="100%"
                 itemCount={itemCount}
                 itemSize={appHeight}
                 onItemsRendered={onVerticalScroll}

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -16,7 +16,7 @@ import PwaDesktopModal from './PwaDesktopModal';
 
 const TopBar = () => {
   const { user } = useUser();
-  const { openAccountPanel } = useVideoGrid();
+  const { setActiveModal } = useVideoGrid();
   const { t } = useTranslation();
   const { addToast } = useToast();
   const [isLoginPanelOpen, setIsLoginPanelOpen] = useState(false);
@@ -91,7 +91,7 @@ const TopBar = () => {
           // --- WIDOK DLA ZALOGOWANYCH UŻYTKOWNIKÓW ---
           <>
             <div className="flex justify-start">
-              <Button variant="ghost" size="icon" onClick={openAccountPanel} aria-label={t('accountMenuButton')}>
+              <Button variant="ghost" size="icon" onClick={() => setActiveModal('account')} aria-label={t('accountMenuButton')}>
                 {user.avatar ? (
                   <Image
                     src={user.avatar}

--- a/context/VideoGridContext.tsx
+++ b/context/VideoGridContext.tsx
@@ -123,7 +123,7 @@ function reducer(state: State, action: Action): State {
       if (newColumnsState[mergedX]) {
         const slideIndex = newColumnsState[mergedX].findIndex(slide => slide.id === mergedId);
         if (slideIndex !== -1) {
-          newColumnsState[mergedX][slideIndex] = { ...newColumnsState[mergedX][slideIndex], ...action.payload };
+          newColumnsState[mergedX][slideIndex] = action.payload;
         }
       }
       if (state.activeSlideId === mergedId && action.payload.type === 'video') {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,7 +5,7 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-export function debounce<T extends (...args: unknown[]) => void>(
+export function debounce<T extends (...args: any[]) => void>(
   func: T,
   wait: number
 ): (...args: Parameters<T>) => void {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-icons": "^5.5.0",
-    "react-window": "^2.0.2",
+    "react-window": "1.8.10",
     "react-window-infinite-loader": "^1.0.10",
     "recharts": "^3.1.2",
     "tailwind-merge": "^2.3.0",
@@ -46,6 +46,7 @@
     "@types/node": "24.3.0",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@types/react-window": "1.8.5",
     "@types/web-push": "^3.6.4",
     "@typescript-eslint/eslint-plugin": "^8.41.0",
     "@typescript-eslint/parser": "^8.41.0",
@@ -57,5 +58,8 @@
     "tailwindcss": "^3.4.17",
     "tsx": "^4.20.5",
     "typescript": "5.9.2"
+  },
+  "resolutions": {
+    "@types/react": "18.3.24"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,6 +18,11 @@
     "@csstools/css-tokenizer" "^3.0.3"
     lru-cache "^10.4.3"
 
+"@babel/runtime@^7.0.0":
+  version "7.28.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.3.tgz#75c5034b55ba868121668be5d5bb31cc64e6e61a"
+  integrity sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==
+
 "@csstools/color-helpers@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@csstools/color-helpers/-/color-helpers-5.1.0.tgz#106c54c808cabfd1ab4c602d8505ee584c2996ef"
@@ -199,9 +204,9 @@
   integrity sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.7.0":
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz#607084630c6c033992a082de6e6fbc1a8b52175a"
-  integrity sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.8.0.tgz#0e3b5e45566d1bce1ec47d8aae2fc2ad77ad0894"
+  integrity sha512-MJQFqrZgcW0UNYLGOuQpey/oTN59vyWwplvCGZztn1cKz9agZPPYpJB7h2OMmuu7VLqkvEjN8feFZJmxNF9D+Q==
   dependencies:
     eslint-visitor-keys "^3.4.3"
 
@@ -420,9 +425,9 @@
     "@radix-ui/react-compose-refs" "1.1.2"
 
 "@reduxjs/toolkit@1.x.x || 2.x.x":
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-2.8.2.tgz#f4e9f973c6fc930c1e0f3bf462cc95210c28f5f9"
-  integrity sha512-MYlOhQ0sLdw4ud48FoC5w0dH9VfWQjtCjreKwYTT3l+r427qYC5Y8PihNutepr8XrNaBUDQo9khWUwQxZaqt5A==
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-2.9.0.tgz#d4b12b90c27716a6a507193f8c3b2880729b97d5"
+  integrity sha512-fSfQlSRu9Z5yBkvsNhYF2rPS8cGXn/TZVrlwN1948QyZ8xMZ0JvP50S2acZNaf+o63u6aEeMjipFyksjIcWrog==
   dependencies:
     "@standard-schema/spec" "^1.0.0"
     "@standard-schema/utils" "^0.3.0"
@@ -631,7 +636,14 @@
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.7.tgz#b89ddf2cd83b4feafcc4e2ea41afdfb95a0d194f"
   integrity sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==
 
-"@types/react@^18":
+"@types/react-window@1.8.5":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@types/react-window/-/react-window-1.8.5.tgz#285fcc5cea703eef78d90f499e1457e9b5c02fc1"
+  integrity sha512-V9q3CvhC9Jk9bWBOysPGaWy/Z0lxYcTXLtLipkt2cnRj1JOSFNF7wqGpkScSXMgBwC+fnVRg/7shwgddBG5ICw==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*", "@types/react@18.3.24", "@types/react@^18":
   version "18.3.24"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.24.tgz#f6a5a4c613242dfe3af0dcee2b4ec47b92d9b6bd"
   integrity sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==
@@ -1648,9 +1660,9 @@ ecdsa-sig-formatter@1.0.11:
     safe-buffer "^5.0.1"
 
 electron-to-chromium@^1.5.211:
-  version "1.5.212"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.212.tgz#9b541f90d7d8415ccea94d4be4bb86e73e3f9547"
-  integrity sha512-gE7ErIzSW+d8jALWMcOIgf+IB6lpfsg6NwOhPVwKzDtN2qcBix47vlin4yzSregYDxTCXOUqAZjVY/Z3naS7ww==
+  version "1.5.213"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.213.tgz#f434187f227fb7e67bfcf8243b959cf3ce14013e"
+  integrity sha512-xr9eRzSLNa4neDO0xVFrkXu3vyIzG4Ay08dApecw42Z1NbmCt+keEpXdvlYGVe0wtvY5dhW0Ay0lY0IOfsCg0Q==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -2933,6 +2945,11 @@ math-intrinsics@^1.1.0:
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
 
+"memoize-one@>=3.1.1 <6":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
+  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
+
 merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
@@ -3480,10 +3497,13 @@ react-window-infinite-loader@^1.0.10:
   resolved "https://registry.yarnpkg.com/react-window-infinite-loader/-/react-window-infinite-loader-1.0.10.tgz#30aa264c6b2cc6d41153a65377e337cb83c9bdca"
   integrity sha512-NO/csdHlxjWqA2RJZfzQgagAjGHspbO2ik9GtWZb0BY1Nnapq0auG8ErI+OhGCzpjYJsCYerqUlK6hkq9dfAAA==
 
-react-window@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/react-window/-/react-window-2.0.2.tgz#33db244d767a1eb44783918e72c1a7daf2f6890d"
-  integrity sha512-KCDGR+5qB6hG/eDWCNZku5ERMV21vjMEDJeobqPXI0/foVDaqjf+Fsum4iJu0ftLUTxh9yvZ9t7T+SJ7woOLFw==
+react-window@1.8.10:
+  version "1.8.10"
+  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.10.tgz#9e6b08548316814b443f7002b1cf8fd3a1bdde03"
+  integrity sha512-Y0Cx+dnU6NLa5/EvoHukUD0BklJ8qITCtVEPY1C/nL8wwoZ0b5aEw8Ff1dOVHw7fCzMt55XfJDd8S8W8LCaUCg==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    memoize-one ">=3.1.1 <6"
 
 react@^18:
   version "18.3.1"


### PR DESCRIPTION
This commit resolves a series of cascading build failures that originated from an incorrect version of the `react-window` library being used.

The initial problem was a failed import of `FixedSizeList` from `react-window`. This was due to an unintentional upgrade to `react-window@2.x`, which has a different API than the `1.x` version the application was written for.

The following fixes were implemented:
- Pinned `react-window` dependency to `1.8.10` in `package.json`.
- Installed `@types/react-window` for type definitions.
- Resolved a conflict between `@types/react@18` and `@types/react@19` by adding a `resolutions` field to `package.json`.
- Fixed a series of TypeScript errors and bugs in the application code that were uncovered after the dependency issues were resolved. This included:
  - Correcting the destructuring of the `useVideoGrid` hook in `app/page.tsx`.
  - Adding the required `width` prop to the `FixedSizeList` component.
  - Updating `components/TopBar.tsx` to use the correct `setActiveModal` function.
  - Fixing an improper merge of a discriminated union type in `VideoGridContext.tsx`.
  - Correcting the generic type definition of the `debounce` utility in `lib/utils.ts`.

After these changes, the application now builds successfully.

Note: This approach of downgrading the library was chosen based on explicit user approval, despite an automated code review suggesting a code refactoring instead. The user preferred a working solution with minimal application logic changes.