### PR TITLE
Fix: Resolve build failure in Slide component

### DIFF
--- a/components/Slide.tsx
+++ b/components/Slide.tsx
@@ -67,10 +67,10 @@ const VideoSlideContent = ({ slide }: { slide: VideoSlide }) => {
 
     return (
         <div className="relative w-full h-full bg-black">
-            {!isPlaying ? (
+            {!isPlaying && slide.data ? (
                 <>
                     <Image
-                        src={slide.data.poster!}
+                        src={slide.data.poster}
                         alt={slide.data.title || 'Video poster'}
                         layout="fill"
                         objectFit="cover"


### PR DESCRIPTION
The build was failing due to a TypeScript error in the `VideoSlideContent` component. The `slide.data` property is optional on the `VideoSlide` type, but its `poster` and `title` properties were being accessed without a proper null check.

This change adds a guard to ensure `slide.data` is defined before rendering the `Image` component that depends on it. This makes the component more robust and fixes the build error.