### PR TITLE
Fix: First video does not autoplay on load

### DIFF
--- a/components/MainFeed.tsx
+++ b/components/MainFeed.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useEffect } from 'react';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { VerticalFeed, VideoItem } from 'react-vertical-feed';
 import { useStore } from '@/store/useStore';
@@ -41,6 +41,14 @@ const MainFeed = () => {
   });
 
   const slides = useMemo(() => data?.pages.flatMap(page => page.slides) ?? [], [data]);
+
+  // --- START OF PROPOSED FIX ---
+  useEffect(() => {
+    if (!activeVideo && slides.length > 0) {
+      setActiveVideo(slides[0]);
+    }
+  }, [slides, activeVideo, setActiveVideo]);
+  // --- END OF PROPOSED FIX ---
 
   const videoItems: VideoItem[] = useMemo(() => {
     return slides


### PR DESCRIPTION
The first video in the main feed was not automatically playing on load because the `activeVideo` state was only being set on scroll.

This change adds a `useEffect` hook to `MainFeed.tsx` to set the first video as active as soon as the slide data is loaded, ensuring it autoplays as expected.