### PR TITLE
Fix(MainFeed): Ensure first video autoplays on initial load

### DIFF
--- a/components/MainFeed.tsx
+++ b/components/MainFeed.tsx
@@ -42,14 +42,6 @@ const MainFeed = () => {
 
   const slides = useMemo(() => data?.pages.flatMap(page => page.slides) ?? [], [data]);
 
-  // --- START OF PROPOSED FIX ---
-  useEffect(() => {
-    if (!activeVideo && slides.length > 0) {
-      setActiveVideo(slides[0]);
-    }
-  }, [slides, activeVideo, setActiveVideo]);
-  // --- END OF PROPOSED FIX ---
-
   const videoItems: VideoItem[] = useMemo(() => {
     return slides
       .filter(
@@ -66,6 +58,18 @@ const MainFeed = () => {
       controls: false,
     }));
   }, [slides]);
+
+  // --- START OF NEW FIX ---
+  // Nowa logika do obsługi pierwszego slajdu
+  useEffect(() => {
+    if (slides.length > 0 && !activeVideo) {
+      const firstVideoItem = videoItems.find(item => item.id === slides[0].id);
+      if (firstVideoItem) {
+        setActiveVideo(firstVideoItem.metadata?.slide);
+      }
+    }
+  }, [slides, activeVideo, setActiveVideo, videoItems]);
+  // --- END OF NEW FIX ---
 
   const handleEndReached = () => {
     if (hasNextPage) {


### PR DESCRIPTION
The initial video in the feed failed to autoplay because the `activeVideo` state was being set before the `react-vertical-feed` component was fully initialized with the video items. This resulted in a synchronization issue where the player would not react to the state change.

This commit replaces the previous `useEffect` with a more robust one. The new effect waits for the `videoItems` array to be populated from the fetched `slides`. It then finds the first video item and sets the `activeVideo` state using the metadata from that item. This ensures the video player is ready and correctly handles the initial video, fixing the autoplay bug.