### PR TITLE
Feat: Improve preloader and video start-up flow

### DIFF
--- a/components/Preloader.tsx
+++ b/components/Preloader.tsx
@@ -20,11 +20,12 @@ const fetchSlides = async () => {
 
 const Preloader: React.FC = () => {
   const { t, selectInitialLang, isLangSelected } = useTranslation();
-  const { setPreloadedSlide } = useStore();
+  const { setPreloadedSlide, isFirstVideoReady, setIsMuted } = useStore(state => ({
+    setPreloadedSlide: state.setPreloadedSlide,
+    isFirstVideoReady: state.isFirstVideoReady,
+    setIsMuted: state.setIsMuted,
+  }), shallow);
   const [isHiding, setIsHiding] = useState(false);
-  const [contentVisible, setContentVisible] = useState(false);
-  const [showLoadingBar, setShowLoadingBar] = useState(false);
-  const [loadingProgress, setLoadingProgress] = useState(0);
 
   // Rozpoczęcie ładowania danych od razu, zanim użytkownik wybierze język
   const { data, isLoading: isQueryLoading, isFetched } = useQuery({
@@ -35,46 +36,15 @@ const Preloader: React.FC = () => {
 
   const handleLangSelect = (lang: 'pl' | 'en') => {
     selectInitialLang(lang);
-    setShowLoadingBar(true); // Pokaż pasek ładowania
+    setIsMuted(false); // Unmute the video
+    setIsHiding(true); // Hide the preloader
   };
-
-  useEffect(() => {
-    const timer = setTimeout(() => setContentVisible(true), 500);
-    return () => clearTimeout(timer);
-  }, []);
 
   useEffect(() => {
     if (isFetched && data?.slides.length > 0) {
       setPreloadedSlide(data.slides[0]);
     }
   }, [data, isFetched, setPreloadedSlide]);
-
-  useEffect(() => {
-    // Symulacja ładowania wideo po wyborze języka
-    if (showLoadingBar) {
-      const interval = setInterval(() => {
-        setLoadingProgress(prev => {
-          if (prev >= 100) {
-            clearInterval(interval);
-            setIsHiding(true); // Ukryj preloader, gdy gotowe
-            return 100;
-          }
-          // Ten warunek jest kluczowy - czekamy, aż dane będą gotowe
-          if (isFetched) {
-            return prev + 10;
-          }
-          return prev;
-        });
-      }, 50);
-      return () => clearInterval(interval);
-    }
-  }, [showLoadingBar, isFetched]);
-
-  useEffect(() => {
-      if (isLangSelected && !isQueryLoading) {
-          setIsHiding(true);
-      }
-  }, [isLangSelected, isQueryLoading]);
 
   return (
     <AnimatePresence>
@@ -113,51 +83,39 @@ const Preloader: React.FC = () => {
               />
             </motion.div>
           </motion.div>
-          {showLoadingBar ? (
-            <motion.div
-              className="w-full max-w-sm flex flex-col items-center justify-center gap-4"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-            >
-              <p className="text-white">Ładowanie...</p>
-              <div className="w-full h-2 bg-white/20 rounded-full">
-                <motion.div
-                  className="h-full bg-pink-500 rounded-full"
-                  initial={{ width: 0 }}
-                  animate={{ width: `${loadingProgress}%` }}
-                />
-              </div>
-            </motion.div>
-          ) : (
-            <motion.div
-              className="w-full max-w-sm flex flex-col items-center justify-center"
-              initial={{ opacity: 0, y: 50 }}
-              animate={{ opacity: contentVisible ? 1 : 0, y: contentVisible ? 0 : 50 }}
-              transition={{ duration: 0.5, ease: 'easeOut', delay: 0.5 }}
-            >
-              <div className="text-center w-full flex flex-col items-center">
-                <h2 className="text-xl font-semibold text-white mb-6">{t('selectLang')}</h2>
-                <div className="flex flex-col gap-4 w-full">
-                  <motion.button
-                    onClick={() => handleLangSelect('pl')}
-                    className="bg-white/5 border border-white/20 hover:bg-white/10 text-base py-6 rounded-md"
-                    whileTap={{ scale: 0.95 }}
-                    transition={{ duration: 0.2 }}
-                  >
-                    {t('polish')}
-                  </motion.button>
-                  <motion.button
-                    onClick={() => handleLangSelect('en')}
-                    className="bg-white/5 border border-white/20 hover:bg-white/10 text-base py-6 rounded-md"
-                    whileTap={{ scale: 0.95 }}
-                    transition={{ duration: 0.2 }}
-                  >
-                    {t('english')}
-                  </motion.button>
+          <AnimatePresence>
+            {isFirstVideoReady && (
+              <motion.div
+                className="w-full max-w-sm flex flex-col items-center justify-center"
+                initial={{ opacity: 0, y: 50 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 50 }}
+                transition={{ duration: 0.5, ease: 'easeOut' }}
+              >
+                <div className="text-center w-full flex flex-col items-center">
+                  <h2 className="text-xl font-semibold text-white mb-6">{t('selectLang')}</h2>
+                  <div className="flex flex-col gap-4 w-full">
+                    <motion.button
+                      onClick={() => handleLangSelect('pl')}
+                      className="bg-white/5 border border-white/20 hover:bg-white/10 text-base py-6 rounded-md"
+                      whileTap={{ scale: 0.95 }}
+                      transition={{ duration: 0.2 }}
+                    >
+                      {t('polish')}
+                    </motion.button>
+                    <motion.button
+                      onClick={() => handleLangSelect('en')}
+                      className="bg-white/5 border border-white/20 hover:bg-white/10 text-base py-6 rounded-md"
+                      whileTap={{ scale: 0.95 }}
+                      transition={{ duration: 0.2 }}
+                    >
+                      {t('english')}
+                    </motion.button>
+                  </div>
                 </div>
-              </div>
-            </motion.div>
-          )}
+              </motion.div>
+            )}
+          </AnimatePresence>
         </motion.div>
       )}
     </AnimatePresence>

--- a/store/useStore.ts
+++ b/store/useStore.ts
@@ -8,14 +8,18 @@ interface AppState {
   activeModal: ModalType;
   isLoading: boolean;
   error: Error | null;
-  activeVideo: Slide | null; // Renamed from activeSlide
-  isPreloading: boolean; // Nowe: śledzi, czy preloader jest aktywny
-  preloadedSlide: Slide | null; // Nowe: przechowuje wstępnie załadowany slajd
+  activeVideo: Slide | null;
+  isPreloading: boolean;
+  preloadedSlide: Slide | null;
+  isFirstVideoReady: boolean;
+  isMuted: boolean;
 
   // Actions
   setActiveVideo: (video: Slide | null) => void;
   setActiveModal: (modal: ModalType) => void;
-  setPreloadedSlide: (slide: Slide | null) => void; // Nowe: akcja do ustawiania preładowanego slajdu
+  setPreloadedSlide: (slide: Slide | null) => void;
+  setIsFirstVideoReady: (isReady: boolean) => void;
+  setIsMuted: (isMuted: boolean) => void;
 
   // Computed properties (selectors)
   isAnyModalOpen: () => boolean;
@@ -27,8 +31,10 @@ export const useStore = create<AppState>((set, get) => ({
   isLoading: true,
   error: null,
   activeVideo: null,
-  isPreloading: true, // Zaczynamy w trybie preloadingu
+  isPreloading: true,
   preloadedSlide: null,
+  isFirstVideoReady: false,
+  isMuted: true,
 
   // --- ACTIONS ---
   setActiveVideo: (video) => set({ activeVideo: video }),
@@ -36,6 +42,10 @@ export const useStore = create<AppState>((set, get) => ({
   setActiveModal: (modal) => set({ activeModal: modal }),
 
   setPreloadedSlide: (slide) => set({ preloadedSlide: slide, isPreloading: false }),
+
+  setIsFirstVideoReady: (isReady) => set({ isFirstVideoReady: isReady }),
+
+  setIsMuted: (isMuted) => set({ isMuted: isMuted }),
 
 
   // --- COMPUTED / SELECTORS ---


### PR DESCRIPTION
This commit revamps the application's startup sequence to provide a smoother user experience and fix several issues.

The key changes include:
- A new preloading flow where the initial video is buffered in the background before the language selection is presented to the user. This eliminates a jarring second preloader.
- The first video now plays with sound after the user interacts with the language selection panel, which was a key requirement.
- A fix for an issue on Android where the first video would not load and would show a black screen.
- The implementation uses the global Zustand store to coordinate state between the Preloader and the MainFeed components.
- A workaround using `querySelector` was implemented to detect when a video is ready to play, due to limitations in the `react-vertical-feed` library. A detailed comment has been added to explain this.