### PR TITLE
Fix: Import shallow in Preloader component

### DIFF
--- a/components/Preloader.tsx
+++ b/components/Preloader.tsx
@@ -5,6 +5,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslation } from '@/context/LanguageContext';
 import Image from 'next/image';
 import { useStore } from '@/store/useStore';
+import { shallow } from 'zustand/shallow';
 import { useQuery } from '@tanstack/react-query';
 import { VideoItem } from 'react-vertical-feed';
 import { Slide as SlideType } from '@/lib/types';


### PR DESCRIPTION
This commit fixes a build error in the Preloader component. The `shallow` function from Zustand was being used without being imported, which caused a `TypeError: Cannot find name 'shallow'`. This change adds the necessary import statement to resolve the error.