### PR TITLE
Fix: Force manual video playback to resolve Android issue

### DIFF
--- a/components/Preloader.tsx
+++ b/components/Preloader.tsx
@@ -18,7 +18,7 @@ const fetchSlides = async () => {
 };
 
 const Preloader: React.FC = () => {
-  const { t, selectInitialLang, isLangSelected } = useTranslation();
+  const { t, selectInitialLang } = useTranslation();
   const { setPreloadedSlide, setIsMuted } = useStore(
     (state) => ({
       setPreloadedSlide: state.setPreloadedSlide,
@@ -29,41 +29,32 @@ const Preloader: React.FC = () => {
 
   const [isHiding, setIsHiding] = useState(false);
   const [showLangButtons, setShowLangButtons] = useState(false);
-  const [showLoadingIndicator, setShowLoadingIndicator] = useState(false);
 
+  // Fetch the first slide's data in the background.
+  // This query will only run once and the data will be cached.
   const { data, isFetched } = useQuery({
       queryKey: ['slides', 'preload'],
       queryFn: fetchSlides,
-      staleTime: Infinity, // Preload only once
+      staleTime: Infinity,
   });
 
-  // Effect to show language buttons after a short delay
-  useEffect(() => {
-    const timer = setTimeout(() => setShowLangButtons(true), 500);
-    return () => clearTimeout(timer);
-  }, []);
-
-  // Effect to store the preloaded slide once fetched
+  // Once the data is fetched, set it in our global store.
   useEffect(() => {
     if (isFetched && data?.slides.length > 0) {
       setPreloadedSlide(data.slides[0]);
     }
   }, [data, isFetched, setPreloadedSlide]);
 
-  // Effect to hide the preloader once all conditions are met
+  // Show language buttons after a brief moment.
   useEffect(() => {
-    if (isLangSelected && isFetched) {
-      setIsHiding(true);
-    }
-  }, [isLangSelected, isFetched]);
+    const timer = setTimeout(() => setShowLangButtons(true), 500);
+    return () => clearTimeout(timer);
+  }, []);
 
   const handleLangSelect = (lang: 'pl' | 'en') => {
-    // Immediately provide feedback by showing the loader
-    setShowLoadingIndicator(true);
     selectInitialLang(lang);
-    // We do not set isMuted here, assuming the user wants sound if they interact
-    // Let's stick to the user's request: interaction should enable sound.
-    setIsMuted(false);
+    setIsMuted(false); // Unmute the app as per user's request for interaction-based sound.
+    setIsHiding(true);  // Immediately start hiding the preloader.
   };
 
   return (
@@ -72,12 +63,11 @@ const Preloader: React.FC = () => {
         <motion.div
           className="fixed inset-0 bg-black z-[10000] overflow-hidden flex flex-col items-center justify-center p-4 gap-8"
           initial={{ opacity: 1 }}
-          exit={{ opacity: 0, transition: { duration: 0.5, delay: 0.3 } }}
+          exit={{ opacity: 0, transition: { duration: 0.3, delay: 0.2 } }}
         >
           <motion.div
             className="w-[150px] h-[150px] flex-shrink-0"
-            initial={{ opacity: 0, scale: 0.9 }}
-            animate={{ opacity: 1, scale: 1 }}
+            animate={{ opacity: showLangButtons ? 1 : 0 }}
             transition={{ duration: 0.5, ease: 'easeOut' }}
           >
             <motion.div
@@ -99,40 +89,30 @@ const Preloader: React.FC = () => {
             {showLangButtons && (
               <motion.div
                 className="w-full max-w-sm"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0 }}
+                transition={{ duration: 0.4, ease: 'easeOut' }}
               >
-                {showLoadingIndicator ? (
-                  <div className="w-full h-2 bg-white/20 rounded-full overflow-hidden">
-                    <motion.div
-                      className="h-full bg-pink-500"
-                      initial={{ x: "-100%" }}
-                      animate={{ x: "0%" }}
-                      transition={{ duration: 1.5, repeat: Infinity, ease: "linear" }}
-                    />
+                <div className="text-center w-full flex flex-col items-center">
+                  <h2 className="text-xl font-semibold text-white mb-6">{t('selectLang')}</h2>
+                  <div className="flex flex-col gap-4 w-full">
+                    <motion.button
+                      onClick={() => handleLangSelect('pl')}
+                      className="bg-white/5 border border-white/20 hover:bg-white/10 text-base py-6 rounded-md"
+                      whileTap={{ scale: 0.95 }}
+                    >
+                      {t('polish')}
+                    </motion.button>
+                    <motion.button
+                      onClick={() => handleLangSelect('en')}
+                      className="bg-white/5 border border-white/20 hover:bg-white/10 text-base py-6 rounded-md"
+                      whileTap={{ scale: 0.95 }}
+                    >
+                      {t('english')}
+                    </motion.button>
                   </div>
-                ) : (
-                  <div className="text-center w-full flex flex-col items-center">
-                    <h2 className="text-xl font-semibold text-white mb-6">{t('selectLang')}</h2>
-                    <div className="flex flex-col gap-4 w-full">
-                      <motion.button
-                        onClick={() => handleLangSelect('pl')}
-                        className="bg-white/5 border border-white/20 hover:bg-white/10 text-base py-6 rounded-md"
-                        whileTap={{ scale: 0.95 }}
-                      >
-                        {t('polish')}
-                      </motion.button>
-                      <motion.button
-                        onClick={() => handleLangSelect('en')}
-                        className="bg-white/5 border border-white/20 hover:bg-white/10 text-base py-6 rounded-md"
-                        whileTap={{ scale: 0.95 }}
-                      >
-                        {t('english')}
-                      </motion.button>
-                    </div>
-                  </div>
-                )}
+                </div>
               </motion.div>
             )}
           </AnimatePresence>


### PR DESCRIPTION
This commit provides a definitive fix for a complex issue where videos would not play on Android devices after the initial language selection.

The root cause was determined to be the unreliability of the `autoPlay` attribute on Android browsers after a component transition, which 'loses' the initial user gesture.

This solution implements the following:
1.  **Simplified `Preloader.tsx`**: The preloader is now much simpler. It fetches initial data in the background and hides immediately upon language selection. This also fixes a UX bug on iPhone where the preloader would linger over the already-playing video.
2.  **Manual Playback in `MainFeed.tsx`**: All playback logic is now in `MainFeed.tsx`. A `useEffect` hook monitors the active video. When the first slide becomes active, the code finds the corresponding `<video>` element and programmatically calls `.play()` on it. This forceful approach bypasses the unreliable `autoPlay` and ensures the video starts as intended.
3.  **Clean Code**: Removed dead code related to `isFirstVideoReady` and fixed a React linting warning for exhaustive dependencies.