### PR TITLE
feat: Implement feed improvements and bugfixes

### DIFF
--- a/app/api/slides/route.ts
+++ b/app/api/slides/route.ts
@@ -20,13 +20,17 @@ export async function GET(request: NextRequest) {
     const slides = await db.getSlides({ limit, cursor, currentUserId });
 
     let nextCursor: string | null = null;
-    if (slides.length === limit) {
-      const lastSlide = slides[slides.length - 1];
+    let slidesToSend = slides;
+
+    if (slides.length > limit) {
+      // If we got more slides than the limit, there's a next page.
+      const lastSlide = slides[limit - 1]; // The last slide of the *current* page
       nextCursor = lastSlide.createdAt.toString();
+      slidesToSend = slides.slice(0, limit); // Send only the requested number of slides
     }
 
     return NextResponse.json({
-      slides,
+      slides: slidesToSend,
       nextCursor,
     });
   } catch (error) {

--- a/components/MainFeed.tsx
+++ b/components/MainFeed.tsx
@@ -16,6 +16,8 @@ const fetchSlides = async ({ pageParam = '' }) => {
 
 const MainFeed = () => {
   const loadMoreRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
   const {
     data,
     fetchNextPage,
@@ -55,6 +57,12 @@ const MainFeed = () => {
     };
   }, [hasNextPage, fetchNextPage]);
 
+  const scrollToTop = () => {
+    scrollContainerRef.current?.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
 
   if (isLoading && slides.length === 0) {
     return <div className="w-screen h-screen bg-black flex items-center justify-center"><Skeleton className="w-full h-full" /></div>;
@@ -65,10 +73,14 @@ const MainFeed = () => {
   }
 
   return (
-    <div className="w-full h-screen overflow-y-scroll snap-y snap-mandatory">
+    <div ref={scrollContainerRef} className="w-full h-screen overflow-y-scroll snap-y snap-mandatory">
       {slides.map((slide, index) => (
         <div key={slide.id} className="h-full w-full snap-start">
-          <Slide slide={slide} />
+          <Slide
+            slide={slide}
+            isLastSlide={!hasNextPage && index === slides.length - 1}
+            onScrollToTop={scrollToTop}
+          />
         </div>
       ))}
        {hasNextPage && (

--- a/components/Slide.tsx
+++ b/components/Slide.tsx
@@ -24,6 +24,8 @@ interface ImageContentProps {
 }
 interface SlideUIProps {
     slide: SlideUnionType;
+    isLastSlide?: boolean;
+    onScrollToTop?: () => void;
 }
 
 // --- Sub-components ---
@@ -54,7 +56,7 @@ const ImageContent = ({ slide }: ImageContentProps) => {
   );
 };
 
-const SlideUI = ({ slide }: SlideUIProps) => {
+const SlideUI = ({ slide, isLastSlide, onScrollToTop }: SlideUIProps) => {
     const {
         activeModal,
         setActiveModal,
@@ -88,7 +90,9 @@ const SlideUI = ({ slide }: SlideUIProps) => {
         // We only toggle play if the click is on the container itself,
         // not on the UI elements within it.
         if (e.target === e.currentTarget) {
-            togglePlay();
+            // This is handled by the VideoPlayer's own onClick now.
+            // We could call togglePlay() here but it might conflict.
+            // For now, let's leave this to the VideoPlayer.
         }
     }
 
@@ -104,6 +108,17 @@ const SlideUI = ({ slide }: SlideUIProps) => {
         {/* Bottom gradient */}
         <div className="absolute inset-x-0 bottom-0 h-48 bg-gradient-to-t from-black/50 to-transparent pointer-events-none" />
 
+        {isLastSlide && (
+            <div className="absolute inset-0 flex flex-col items-center justify-center z-30">
+                <p className="text-lg mb-4">To już wszystko!</p>
+                <button
+                    onClick={onScrollToTop}
+                    className="bg-white text-black font-bold py-2 px-4 rounded-full shadow-lg hover:bg-gray-200 transition-colors"
+                >
+                    Wróć na początek
+                </button>
+            </div>
+        )}
 
         {/* UI Controls Container */}
         <div className="relative z-20">
@@ -144,9 +159,11 @@ const SlideUI = ({ slide }: SlideUIProps) => {
 
 interface SlideProps {
     slide: SlideUnionType;
+    isLastSlide?: boolean;
+    onScrollToTop?: () => void;
 }
 
-const Slide = memo<SlideProps>(({ slide}) => {
+const Slide = memo<SlideProps>(({ slide, isLastSlide, onScrollToTop }) => {
     const renderContent = () => {
         switch (slide.type) {
             case 'video':
@@ -165,7 +182,7 @@ const Slide = memo<SlideProps>(({ slide}) => {
     return (
         <div className="relative w-full h-full bg-black">
             {renderContent()}
-            <SlideUI slide={slide} />
+            <SlideUI slide={slide} isLastSlide={isLastSlide} onScrollToTop={onScrollToTop} />
         </div>
     );
 });

--- a/components/VideoPlayer.tsx
+++ b/components/VideoPlayer.tsx
@@ -89,7 +89,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({ hlsUrl }) => {
       },
       {
         root: null,
-        rootMargin: '0px',
+        rootMargin: '100% 0px', // Preload one viewport height away
         threshold: 0.6, // 60% of the video must be visible to play
       }
     );
@@ -106,9 +106,23 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({ hlsUrl }) => {
     };
   }, []);
 
+  const handleVideoClick = () => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    if (video.paused) {
+      video.play();
+      playVideo();
+    } else {
+      video.pause();
+      pauseVideo();
+    }
+  };
+
   return (
     <video
       ref={videoRef}
+      onClick={handleVideoClick}
       className="absolute top-0 left-0 w-full h-full object-cover z-0"
       playsInline
       loop

--- a/lib/db-postgres.ts
+++ b/lib/db-postgres.ts
@@ -314,6 +314,7 @@ export async function getSlides(options: { limit?: number, cursor?: string, curr
     const cursorDate = cursor ? new Date(parseInt(cursor, 10)) : null;
 
     // We need to build the query dynamically to include the WHERE clause for the cursor.
+    // We fetch limit + 1 to determine if there's a next page.
     let query = `
         SELECT
             s.*,
@@ -324,7 +325,7 @@ export async function getSlides(options: { limit?: number, cursor?: string, curr
         LEFT JOIN likes l ON s.id = l."slideId"
         LEFT JOIN comments c ON s.id = c."slideId"
     `;
-    const params: any[] = [limit];
+    const params: any[] = [limit + 1];
 
     if (cursorDate) {
         query += ` WHERE s."createdAt" < $3`;


### PR DESCRIPTION
This commit addresses user feedback on the new CSS Snap Scroll feed.

- fix(api): Corrects the slide pagination logic to fetch `limit + 1` items, preventing a false `hasNextPage` positive and fixing a bug where a loader would appear for an empty final page.
- feat(player): Implements tap-to-pause functionality on the video player.
- feat(player): Improves video preloading by setting a `rootMargin` on the IntersectionObserver to start buffering content before it enters the viewport.
- feat(ui): Adds a 'Back to Top' button on the final slide to provide a clear action when the user reaches the end of the feed.