### PR TITLE
feat: Improve preloader, iOS instructions, and videos

### DIFF
--- a/index.html
+++ b/index.html
@@ -332,8 +332,8 @@
             <button id="pwa-ios-close-button" class="pwa-ios-close-button">&times;</button>
         </div>
         <div class="pwa-ios-body">
-            <p>1. Stuknij ikonę **udostępniania** w przeglądarce.</p>
-            <p>2. Wybierz **"Dodaj do ekranu początkowego"**.</p>
+            <p>1. Stuknij ikonę udostępniania <svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" class="ios-instruction-icon" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="17 8 12 3 7 8"></polyline><line x1="12" y1="3" x2="12" y2="15"></line></svg> w przeglądarce.</p>
+            <p>2. Wybierz "Dodaj do ekranu początkowego" <svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" class="ios-instruction-icon" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="12" y1="8" x2="12" y2="16"></line><line x1="8" y1="12" x2="16" y2="12"></line></svg>.</p>
             <p>3. Potwierdź, a aplikacja pojawi się na Twoim ekranie!</p>
         </div>
     </div>

--- a/prosta-wersja/script.js
+++ b/prosta-wersja/script.js
@@ -166,7 +166,7 @@
                         'likeId': '1',
                         'user': 'Paweł Polutek',
                         'description': 'To jest dynamicznie załadowany opis dla pierwszego slajdu. Działa!',
-                        'mp4Url': 'https://pawelperfect.pl/wp-content/uploads/2025/07/17169505-hd_1080_1920_30fps.mp4',
+                        'mp4Url': 'https://cdn.pixabay.com/video/2024/08/16/226795_large.mp4',
                         'hlsUrl': null,
                         'poster': '',
                         'avatar': 'https://i.pravatar.cc/100?u=pawel',
@@ -180,7 +180,7 @@
                         'likeId': '2',
                         'user': 'Web Dev',
                         'description': 'Kolejny slajd, kolejne wideo. #efficiency',
-                        'mp4Url': 'https://pawelperfect.pl/wp-content/uploads/2025/07/4434150-hd_1080_1920_30fps-1.mp4',
+                        'mp4Url': 'https://cdn.pixabay.com/video/2023/02/16/150957-799711743_large.mp4',
                         'hlsUrl': null,
                         'poster': '',
                         'avatar': 'https://i.pravatar.cc/100?u=webdev',
@@ -194,7 +194,7 @@
                         'likeId': '3',
                         'user': 'Tajemniczy Tester',
                         'description': 'Ten slajd jest tajny! 🤫',
-                        'mp4Url': 'https://pawelperfect.pl/wp-content/uploads/2025/07/4678261-hd_1080_1920_25fps.mp4',
+                        'mp4Url': 'https://cdn.pixabay.com/video/2022/07/24/125314-733046618_tiny.mp4',
                         'hlsUrl': null,
                         'poster': '',
                         'avatar': 'https://i.pravatar.cc/100?u=tester',
@@ -202,20 +202,6 @@
                         'initialLikes': 2,
                         'isLiked': false,
                         'initialComments': 2
-                    },
-                    {
-                        'id': 'slide-004',
-                        'likeId': '4',
-                        'user': 'Artysta AI',
-                        'description': 'Generowane przez AI, renderowane przez przeglądarkę. #future',
-                        'mp4Url': 'https://pawelperfect.pl/wp-content/uploads/2025/07/AdobeStock_631182722-online-video-cutter.com_.mp4',
-                        'hlsUrl': null,
-                        'poster': '',
-                        'avatar': 'https://i.pravatar.cc/100?u=ai-artist',
-                        'access': 'public',
-                        'initialLikes': 890,
-                        'isLiked': false,
-                        'initialComments': 890
                     }
                 ]
             };
@@ -1628,6 +1614,32 @@
             const iosInstructions = document.getElementById('pwa-ios-instructions');
             const iosCloseButton = document.getElementById('pwa-ios-close-button');
 
+            function showInstallBar() {
+                if (!installBar || window.matchMedia('(display-mode: standalone)').matches) {
+                    return;
+                }
+
+                const preloader = document.getElementById('preloader');
+                // Check if preloader is visible and not already in the process of hiding
+                if (preloader && preloader.style.display !== 'none' && !preloader.classList.contains('preloader-hiding')) {
+                    const observer = new MutationObserver((mutationsList, observer) => {
+                        for(const mutation of mutationsList) {
+                            if (mutation.type === 'attributes' && mutation.attributeName === 'style') {
+                                if (preloader.style.display === 'none') {
+                                    installBar.classList.remove('hidden');
+                                    observer.disconnect();
+                                    return;
+                                }
+                            }
+                        }
+                    });
+                    observer.observe(preloader, { attributes: true });
+                } else if (!preloader || preloader.style.display === 'none') {
+                    // If preloader is already gone, show the bar
+                    installBar.classList.remove('hidden');
+                }
+            }
+
             function init() {
                 if (window.matchMedia('(display-mode: standalone)').matches) {
                     return; // Already installed
@@ -1638,9 +1650,7 @@
                 window.addEventListener('beforeinstallprompt', (e) => {
                     e.preventDefault();
                     installPromptEvent = e;
-                    if (installBar) {
-                        installBar.classList.remove('hidden');
-                    }
+                    showInstallBar();
                 });
 
                 if (installButton) {
@@ -1659,9 +1669,9 @@
                     });
                 }
 
-                // Show the bar for iOS immediately if not installed
-                if(isIOS && installBar) {
-                     installBar.classList.remove('hidden');
+                // Show the bar for iOS if not installed, but respect preloader
+                if (isIOS) {
+                     showInstallBar();
                 }
 
                 if (iosCloseButton) {

--- a/prosta-wersja/style.css
+++ b/prosta-wersja/style.css
@@ -629,7 +629,7 @@
             fill: none;
         }
         .tiktok-symulacja .notification-bell svg {
-            stroke: white;
+    stroke: white !important;
             fill: none;
         }
         .tiktok-symulacja .notification-dot {
@@ -2002,3 +2002,11 @@
         .pwa-ios-body p {
             margin-bottom: 0.75rem;
         }
+
+.ios-instruction-icon {
+    display: inline-block;
+    width: 1.2em;
+    height: 1.2em;
+    vertical-align: -0.2em;
+    margin: 0 0.1em;
+}


### PR DESCRIPTION
This commit introduces several user experience improvements based on user feedback.

- PWA install prompt is now deferred until after the preloader has finished, preventing the prompt from overlapping with the loading screen.
- iOS PWA installation instructions have been updated to include graphical SVG icons for 'share' and 'add to home screen' actions, making them more intuitive.
- Broken video links have been replaced with new, working videos. The slide data has been updated to reflect the new set of videos.
- The notification bell icon's color is now forced to white to ensure it is always visible, regardless of other styles.