### PR TITLE
feat: Update top bar and notification styles

### DIFF
--- a/prosta-wersja/style.css
+++ b/prosta-wersja/style.css
@@ -251,6 +251,7 @@
             color: white;
             z-index: 1;
             font-family: 'Manrope', sans-serif;
+            padding-top: var(--topbar-height);
         }
         .tiktok-symulacja * {
             box-sizing: border-box;
@@ -344,7 +345,8 @@
             backdrop-filter: blur(8px);
         }
         .tiktok-symulacja .topbar {
-            position: sticky; /* Zmieniono z relative na fixed, a teraz na sticky */
+            position: fixed;
+            visibility: hidden;
             display: flex;
             justify-content: center; /* Center the middle element */
             align-items: center;
@@ -360,6 +362,10 @@
             color: inherit;
             border-bottom: 1px solid rgba(255, 255, 255, 0.15); /* Subtle separator */
             transition: border-color 0.3s ease-out;
+        }
+
+        .active-slide .tiktok-symulacja .topbar {
+            visibility: visible;
         }
         .tiktok-symulacja .topbar.login-panel-active {
             border-bottom-color: transparent;
@@ -630,7 +636,7 @@
         }
         .tiktok-symulacja .notification-bell svg {
     stroke: white !important;
-            fill: white;
+            fill: white !important;
         }
         .tiktok-symulacja .notification-dot {
             position: absolute;
@@ -638,9 +644,9 @@
             right: 11px;
             width: 8px;
             height: 8px;
-            background-color: var(--accent-color);
+            background-color: white;
             border-radius: 50%;
-            border: 2px solid #6F6F6F;
+            border: 2px solid white;
         }
 
         /* ==========================================================================
@@ -972,7 +978,7 @@
            ========================================================================== */
         .notification-popup {
             position: fixed;
-            top: calc(var(--topbar-height) + 5px); /* Adjusted spacing */
+            top: 30px; /* Adjusted spacing */
             right: 5px;
             width: 350px;
             max-width: calc(100vw - 10px);


### PR DESCRIPTION
This commit introduces several UI improvements to the top bar and notification components based on user feedback.

1.  **Sticky Top Bar:** The top bar is now fixed to the top of the viewport and remains visible while scrolling through the video feed. This was achieved by changing its position to `fixed` and using the `.active-slide` class to ensure only the top bar of the current slide is visible. Padding was added to the main content area to prevent it from being obscured by the fixed top bar.

2.  **White Notification Bell:** The notification bell icon, including the notification dot, has been restyled to be completely white, providing a cleaner and more consistent look.

3.  **Repositioned Notification Popup:** The notification pop-up window has been moved higher on the page, so it now overlaps the "Ting Tong" text in the top bar as requested.