### PR TITLE
Fix UI elements: preloader logo, bell icon, and notification animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
     <button id="mock-login-toggle">Toggle Login</button>
     <div id="preloader">
         <div class="preloader-icon-container">
-            <img src="https://pawelperfect.pl/wp-content/uploads/2025/07/output-onlinepngtools-1-1.png" alt="Ting Tong Logo" class="splash-icon">
+            <img src="https://cdn3.iconfinder.com/data/icons/shinysocialball/512/delicious_512x512.png" alt="Ting Tong Logo" class="splash-icon">
         </div>
         <div class="preloader-content-container">
             <div class="language-selection">

--- a/prosta-wersja/style.css
+++ b/prosta-wersja/style.css
@@ -630,7 +630,7 @@
         }
         .notification-bell svg {
     stroke: white;
-            fill: white;
+    fill: none;
         }
         .notification-dot {
             position: absolute;
@@ -1120,14 +1120,6 @@
             font-size: 14px;
             line-height: 1.5;
             color: var(--modern-text-secondary);
-            opacity: 0;
-            transform: translateY(-10px);
-            transition: opacity 0.2s ease-out 0.1s, transform 0.2s ease-out 0.1s;
-        }
-
-        .notification-item.expanded .notif-full-details-inner {
-            opacity: 1;
-            transform: translateY(0);
         }
 
         .notification-empty-state {


### PR DESCRIPTION
This commit addresses three UI issues:

1. The preloader logo has been updated to match the PWA splash screen icon defined in `manifest.webmanifest`, as per user confirmation.
2. The notification bell icon's CSS has been adjusted to ensure it is always white and visible.
3. The text animation in the notification modal has been removed, so the full text appears instantly when a notification is expanded.