### PR TITLE
Fix: Always display language selection on preloader

### DIFF
--- a/prosta-wersja/script.js
+++ b/prosta-wersja/script.js
@@ -858,7 +858,28 @@
             }
 
             function _initializePreloader() {
-                // ... same as before
+                // Zawsze wyświetlaj zawartość preloadera z wyborem języka
+                UI.DOM.preloader.classList.add('content-visible');
+
+                // Dodaj detektory zdarzeń dla przycisków wyboru języka
+                const langSelection = UI.DOM.preloader.querySelector('.language-selection');
+                const languageButtons = langSelection.querySelectorAll('button');
+                languageButtons.forEach(button => {
+                    button.addEventListener('click', (event) => {
+                        const selectedLang = event.target.dataset.lang;
+                        // Dalsza logika uruchomienia aplikacji
+                        _startApp(selectedLang);
+                    }, { once: true });
+                });
+
+                // Opcjonalnie: Ustaw domyślny język, jeśli jest zapisany w pamięci
+                const initialLang = localStorage.getItem('tt_lang');
+                if (initialLang) {
+                    const button = langSelection.querySelector(`[data-lang="${initialLang}"]`);
+                    if (button) {
+                        button.classList.add('is-selected');
+                    }
+                }
             }
 
             function _setInitialConfig() {


### PR DESCRIPTION
The application was getting stuck on the splash screen because the language selection panel was incorrectly hidden on some devices.

The `_initializePreloader` function used unreliable device detection to conditionally show the language selector.

This change simplifies the logic by removing the conditional rendering. The language selection panel is now always displayed, allowing the user to manually select a language and start the app, resolving the issue.