### PR TITLE
Fix: Always display language selection on preloader

### DIFF
--- a/prosta-wersja/script.js
+++ b/prosta-wersja/script.js
@@ -858,28 +858,21 @@
             }
 
             function _initializePreloader() {
-                // Zawsze wyświetlaj zawartość preloadera z wyborem języka
-                UI.DOM.preloader.classList.add('content-visible');
+                // To ensure the CSS transition is applied correctly after the initial render,
+                // we add the class inside a short timeout.
+                setTimeout(() => {
+                    UI.DOM.preloader.classList.add('content-visible');
+                }, 50); // A small delay to ensure the browser has painted the initial state.
 
-                // Dodaj detektory zdarzeń dla przycisków wyboru języka
+                // Add event listeners for the language buttons
                 const langSelection = UI.DOM.preloader.querySelector('.language-selection');
                 const languageButtons = langSelection.querySelectorAll('button');
                 languageButtons.forEach(button => {
                     button.addEventListener('click', (event) => {
                         const selectedLang = event.target.dataset.lang;
-                        // Dalsza logika uruchomienia aplikacji
                         _startApp(selectedLang);
                     }, { once: true });
                 });
-
-                // Opcjonalnie: Ustaw domyślny język, jeśli jest zapisany w pamięci
-                const initialLang = localStorage.getItem('tt_lang');
-                if (initialLang) {
-                    const button = langSelection.querySelector(`[data-lang="${initialLang}"]`);
-                    if (button) {
-                        button.classList.add('is-selected');
-                    }
-                }
             }
 
             function _setInitialConfig() {


### PR DESCRIPTION
The application was getting stuck on the splash screen because the language selection panel was not appearing correctly.

This change simplifies the logic in `_initializePreloader` to always show the language selection panel, allowing the user to manually select a language. It also adds a small delay before showing the panel to ensure CSS transitions are applied correctly.

This implementation follows the user's explicit requirement to always show the panel and to not use localStorage for auto-starting the application.