### PR TITLE
Feat: Replace Swiper with native scroll and fix preloader

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,6 @@
     <link rel="dns-prefetch" href="//i.pravatar.cc">
 
     <script data-name="BMC-Widget" data-cfasync="false" src="https://cdnjs.buymeacoffee.com/1.0.0/widget.prod.min.js" data-id="pawelperfect" data-description="Support me on Buy me a coffee!" data-message="" data-color="#FF5F5F" data-position="Right" data-x_margin="18" data-y_margin="18"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css" />
     <link rel="stylesheet" href="prosta-wersja/style.css">
 </head>
 <body>
@@ -129,11 +128,7 @@
         </div>
     </template>
     <!-- Główny kontener na slajdy -->
-    <div id="webyx-container" class="swiper">
-        <div class="swiper-wrapper">
-            <!-- Slajdy będą wstawiane tutaj przez JS -->
-        </div>
-    </div>
+    <div id="webyx-container"></div>
     <!-- Współdzielone Modale i Alerty -->
     <div id="alertBox" role="status" aria-live="polite">
         <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" style="width:18px; height:18px; stroke:white; stroke-width:2; fill:none; margin-right:6px;"><path d="M6 10V8a6 6 0 1 1 12 0v2" /><rect x="4" y="10" width="16" height="10" rx="2" ry="2" /></svg>
@@ -351,7 +346,6 @@
         </div>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
     <script src="prosta-wersja/script.js" defer></script>
 </body>
 </html>

--- a/prosta-wersja/script.js
+++ b/prosta-wersja/script.js
@@ -559,13 +559,18 @@
             }
 
             function renderSlides() {
-                const wrapper = UI.DOM.container.querySelector('.swiper-wrapper');
-                if (!wrapper) return;
-                wrapper.innerHTML = '';
-                slidesData.forEach((data, index) => {
-                    const slideElement = createSlideElement(data, index);
-                    wrapper.appendChild(slideElement);
-                });
+                DOM.container.innerHTML = '';
+                if (slidesData.length === 0) return;
+
+                const addClone = (slideData, index, isFirst) => {
+                    const clone = createSlideElement(slideData, index);
+                    clone.dataset.isClone = 'true';
+                    DOM.container.appendChild(clone);
+                };
+
+                addClone(slidesData[slidesData.length - 1], slidesData.length - 1, false);
+                slidesData.forEach((data, index) => DOM.container.appendChild(createSlideElement(data, index)));
+                addClone(slidesData[0], 0, true);
             }
 
             return { DOM, showAlert, openModal, closeModal, updateUIForLoginState, updateTranslations, applyLikeStateToDom, renderSlides };
@@ -578,8 +583,29 @@
          * ==========================================================================
          */
         const VideoManager = (function() {
+            let hlsPromise = null;
+            const hlsInstances = new Map();
+            const attachedSet = new WeakSet();
+            const retryCounts = new WeakMap();
+            const hlsRecoverCounts = new Map();
+            let playObserver, lazyObserver;
+
+            window.TTStats = window.TTStats || { videoErrors: 0, videoRetries: 0, hlsErrors: 0, hlsRecovered: 0, ttfpSamples: 0, ttfpTotalMs: 0 };
+
+            function _loadHlsLibrary() {
+                if (window.Hls) return Promise.resolve();
+                if (!hlsPromise) {
+                    hlsPromise = import('https://cdn.jsdelivr.net/npm/hls.js@1.5.14/dist/hls.min.js')
+                        .catch(err => {
+                            console.error("Failed to load HLS.js", err);
+                            hlsPromise = null;
+                            throw err;
+                        });
+                }
+                return hlsPromise;
+            }
+
             function _guardedPlay(videoEl) {
-                if (!videoEl) return;
                 if ((Date.now() - State.get('lastUserGestureTimestamp')) < Config.GESTURE_GRACE_PERIOD_MS) {
                     const playPromise = videoEl.play();
                     if (playPromise) {
@@ -593,32 +619,240 @@
                 }
             }
 
-            function _onActiveSlideChanged(swiper) {
-                if (!swiper) return;
+            function _attachSrc(sectionEl) {
+                const video = sectionEl.querySelector('.videoPlayer');
+                if (!video || attachedSet.has(video)) return;
+                const slideId = sectionEl.dataset.slideId;
+                const slideData = slidesData.find(s => s.id === slideId);
 
-                // Pause all videos first
-                swiper.slides.forEach(slide => {
-                    const video = slide.querySelector('.videoPlayer');
-                    if (video && !video.paused) {
-                        video.pause();
-                    }
-                });
+                const canAttach = slideData && !(slideData.access === 'secret' && !State.get('isUserLoggedIn'));
+                if (!canAttach) return;
 
-                // Play video in the active slide
-                const activeSlide = swiper.slides[swiper.activeIndex];
-                if (activeSlide) {
-                    const video = activeSlide.querySelector('.videoPlayer');
-                    const isSecret = activeSlide.querySelector('.tiktok-symulacja').dataset.access === 'secret';
-                    if (video && !(isSecret && !State.get('isUserLoggedIn'))) {
-                        _guardedPlay(video);
+                const setMp4Source = (mp4Url) => {
+                    if (!mp4Url) return;
+                    const finalUrl = Utils.toRelativeIfSameOrigin(Utils.fixProtocol(mp4Url));
+                    const sourceEl = video.querySelector('source');
+                    if (sourceEl) { sourceEl.src = finalUrl; sourceEl.type = 'video/mp4'; }
+                    video.load();
+                };
+
+                if (Config.USE_HLS && slideData.hlsUrl) {
+                    const finalHlsUrl = Utils.toRelativeIfSameOrigin(Utils.fixProtocol(slideData.hlsUrl));
+                    if (video.canPlayType('application/vnd.apple.mpegurl')) {
+                        const sourceEl = video.querySelector('source');
+                        if(sourceEl) { sourceEl.src = finalHlsUrl; sourceEl.type = 'application/vnd.apple.mpegurl'; }
+                        video.load();
+                    } else {
+                        _loadHlsLibrary().then(() => {
+                            if (window.Hls?.isSupported()) {
+                                if (hlsInstances.has(slideId)) hlsInstances.get(slideId).destroy();
+                                const hls = new window.Hls(Config.HLS);
+                                hls.loadSource(finalHlsUrl);
+                                hls.attachMedia(video);
+                                hls.on(window.Hls.Events.ERROR, (event, data) => {
+                                    if (data.fatal) {
+                                       hls.destroy(); hlsInstances.delete(slideId); setMp4Source(slideData.mp4Url);
+                                    }
+                                });
+                                hlsInstances.set(slideId, hls);
+                            } else {
+                                setMp4Source(slideData.mp4Url);
+                            }
+                        }).catch(() => setMp4Source(slideData.mp4Url));
                     }
+                } else {
+                    setMp4Source(slideData.mp4Url);
+                }
+
+                attachedSet.add(video);
+            }
+
+            function _detachSrc(sectionEl) {
+                const video = sectionEl.querySelector('.videoPlayer');
+                if (!video) return;
+                try { video.pause(); } catch(e) {}
+                const slideId = sectionEl.dataset.slideId;
+                if (slideId && hlsInstances.has(slideId)) {
+                  try { hlsInstances.get(slideId).destroy(); } catch(e){}
+                  hlsInstances.delete(slideId);
+                }
+                const sourceEl = video.querySelector('source');
+                if (sourceEl) { sourceEl.removeAttribute('src'); }
+                video.removeAttribute('src');
+                video.load();
+                attachedSet.delete(video);
+            }
+
+            function _startProgressUpdates(video) {
+                _stopProgressUpdates(video);
+                const session = State.get('activeVideoSession');
+                const updateFn = () => {
+                    if (session !== State.get('activeVideoSession') || !video.duration) return;
+                    _updateProgressUI(video);
+                    if (!video.paused) {
+                        video.rAF_id = requestAnimationFrame(updateFn);
+                    }
+                };
+                updateFn();
+            }
+
+            function _stopProgressUpdates(video) {
+                if (video.rAF_id) cancelAnimationFrame(video.rAF_id);
+            }
+
+            function _updateProgressUI(video) {
+                if (State.get('isDraggingProgress') || !video || !video.duration) return;
+                const section = video.closest('.webyx-section');
+                if (!section) return;
+                const percent = (video.currentTime / video.duration) * 100;
+                section.querySelector('.progress-line').style.width = `${percent}%`;
+                section.querySelector('.progress-dot').style.left = `${percent}%`;
+                section.querySelector('.video-progress').setAttribute('aria-valuenow', String(Math.round(percent)));
+            };
+
+            function _onActiveSlideChanged(newIndex, oldIndex = -1) {
+                State.set('activeVideoSession', State.get('activeVideoSession') + 1);
+
+                const allSections = UI.DOM.container.querySelectorAll('.webyx-section:not([data-is-clone="true"])');
+
+                if (oldIndex > -1 && oldIndex < allSections.length) {
+                    const oldSection = allSections[oldIndex];
+                    const oldVideo = oldSection.querySelector('.videoPlayer');
+                    if (oldVideo) { oldVideo.pause(); _stopProgressUpdates(oldVideo); }
+                    oldSection.querySelector('.pause-icon')?.classList.remove('visible');
+                    const progressLine = oldSection.querySelector('.progress-line');
+                    const progressDot = oldSection.querySelector('.progress-dot');
+                    if(progressLine && progressDot) {
+                        progressLine.style.width = '0%';
+                        progressDot.style.left = '0%';
+                    }
+                }
+
+                if (newIndex < allSections.length) {
+                    const newSection = allSections[newIndex];
+                    const newVideo = newSection.querySelector('.videoPlayer');
+                    const isSecret = newSection.querySelector('.tiktok-symulacja').dataset.access === 'secret';
+
+                    if (!(isSecret && !State.get('isUserLoggedIn')) && !State.get('isAutoplayBlocked')) {
+                        _guardedPlay(newVideo);
+                    }
+                    _startProgressUpdates(newVideo);
                 }
             }
 
+            function _initLazyObserver() {
+                if (lazyObserver) return;
+                lazyObserver = new IntersectionObserver((entries) => {
+                    entries.forEach(entry => {
+                        const section = entry.target.closest('.webyx-section');
+                        if (!section) return;
+                        if (entry.isIntersecting) {
+                            _attachSrc(section);
+                        } else if (Config.UNLOAD_FAR_SLIDES) {
+                            const index = parseInt(section.dataset.index, 10);
+                            const distance = Math.abs(index - State.get('currentSlideIndex'));
+                            if (distance > Config.FAR_DISTANCE) _detachSrc(section);
+                        }
+                    });
+                }, { root: UI.DOM.container, rootMargin: Config.PREFETCH_MARGIN, threshold: 0.01 });
+                UI.DOM.container.querySelectorAll('.webyx-section:not([data-is-clone="true"])').forEach(sec => lazyObserver.observe(sec));
+            }
+
             return {
-                initProgressBar: (progressEl, videoEl) => { /* ... (This logic remains unchanged) ... */ },
-                handleVideoClick: (video) => { /* ... (This logic remains unchanged) ... */ },
-                onActiveSlideChanged: _onActiveSlideChanged
+                init: () => {
+                    _initLazyObserver();
+                    playObserver = new IntersectionObserver((entries) => {
+                        entries.forEach(entry => {
+                            if (entry.isIntersecting) {
+                                const newIndex = parseInt(entry.target.dataset.index, 10);
+                                if (newIndex !== State.get('currentSlideIndex')) {
+                                    const oldIndex = State.get('currentSlideIndex');
+                                    State.set('currentSlideIndex', newIndex);
+                                    _onActiveSlideChanged(newIndex, oldIndex);
+                                    UI.updateUIForLoginState();
+                                }
+                            }
+                        });
+                    }, { root: UI.DOM.container, threshold: 0.75 });
+
+                    UI.DOM.container.querySelectorAll('.webyx-section:not([data-is-clone="true"])').forEach(section => playObserver.observe(section));
+                },
+                initProgressBar: (progressEl, videoEl) => {
+                    if (!progressEl || !videoEl) return;
+                    progressEl.classList.add('skeleton');
+                    videoEl.addEventListener('loadedmetadata', () => progressEl.classList.remove('skeleton'), { once: true });
+
+                    let pointerId = null;
+                    const seek = (e) => {
+                        const rect = progressEl.getBoundingClientRect();
+                        const x = ('clientX' in e ? e.clientX : (e.touches?.[0]?.clientX || 0));
+                        const percent = ((x - rect.left) / rect.width) * 100;
+                        const clamped = Math.max(0, Math.min(100, percent));
+                        if (videoEl.duration) videoEl.currentTime = (clamped / 100) * videoEl.duration;
+                        _updateProgressUI(videoEl);
+                    };
+
+                    progressEl.addEventListener('pointerdown', (e) => {
+                        if (pointerId !== null) return;
+                        pointerId = e.pointerId;
+                        State.set('isDraggingProgress', true);
+                        progressEl.classList.add('dragging');
+                        progressEl.setPointerCapture(pointerId);
+                        seek(e);
+                    });
+
+                    progressEl.addEventListener('pointermove', (e) => {
+                        if (e.pointerId !== pointerId) return;
+                        seek(e);
+                    });
+
+                    const endDrag = (e) => {
+                        if (e.pointerId !== pointerId) return;
+                        pointerId = null;
+                        State.set('isDraggingProgress', false);
+                        progressEl.classList.remove('dragging');
+                        _startProgressUpdates(videoEl);
+                    };
+                    progressEl.addEventListener('pointerup', endDrag);
+                    progressEl.addEventListener('pointercancel', endDrag);
+
+                    progressEl.addEventListener('keydown', (e) => {
+                        if (!videoEl.duration) return;
+                        const step = videoEl.duration * 0.05;
+                        switch (e.key) {
+                            case 'ArrowLeft': videoEl.currentTime -= step; break;
+                            case 'ArrowRight': videoEl.currentTime += step; break;
+                            default: return;
+                        }
+                        e.preventDefault();
+                    });
+                },
+                updatePlaybackForLoginChange: (section, isSecret) => {
+                    const video = section.querySelector('.videoPlayer');
+                    const hasSrc = video.querySelector('source')?.getAttribute('src');
+
+                    if (!isSecret && !hasSrc) _attachSrc(section);
+
+                    if (isSecret) {
+                        video.pause();
+                        _stopProgressUpdates(video);
+                        video.currentTime = 0;
+                        _updateProgressUI(video);
+                    } else if (video.paused && document.body.classList.contains('loaded') && !State.get('isDraggingProgress') && !State.get('isAutoplayBlocked')) {
+                       _guardedPlay(video);
+                    }
+                },
+                handleVideoClick: (video) => {
+                    if (State.get('isDraggingProgress')) return;
+                    const pauseIcon = video.closest('.webyx-section')?.querySelector('.pause-icon');
+                    if (video.paused) {
+                        _guardedPlay(video);
+                        pauseIcon?.classList.remove('visible');
+                    } else {
+                        video.pause();
+                        pauseIcon?.classList.add('visible');
+                    }
+                },
             };
         })();
 
@@ -830,47 +1064,46 @@
 
                 UI.renderSlides();
                 UI.updateTranslations();
+                VideoManager.init();
 
                 setTimeout(() => {
                     UI.DOM.preloader.classList.add('preloader-hiding');
                     UI.DOM.container.classList.add('ready');
                     UI.DOM.preloader.addEventListener('transitionend', () => UI.DOM.preloader.style.display = 'none', { once: true });
-
-                    if (typeof Swiper !== 'undefined') {
-                        swiper = new Swiper('.swiper', {
-                            direction: 'vertical',
-                            loop: true,
-                            on: {
-                                init: function (swiper) {
-                                    VideoManager.onActiveSlideChanged(swiper);
-                                },
-                                slideChange: function (swiper) {
-                                    State.set('currentSlideIndex', swiper.realIndex);
-                                    VideoManager.onActiveSlideChanged(swiper);
-                                },
-                            },
-                        });
-                    } else {
-                        console.error('Swiper library not loaded!');
-                    }
-
                 }, 1000);
+
+                if (slidesData.length > 0) {
+                    const viewHeight = window.innerHeight;
+                    UI.DOM.container.classList.add('no-transition');
+                    UI.DOM.container.scrollTo({ top: viewHeight, behavior: 'auto' });
+                    requestAnimationFrame(() => {
+                        UI.DOM.container.classList.remove('no-transition');
+                        UI.DOM.container.addEventListener('scroll', () => {
+                            clearTimeout(window.scrollEndTimeout);
+                            window.scrollEndTimeout = setTimeout(() => {
+                                const physicalIndex = Math.round(UI.DOM.container.scrollTop / viewHeight);
+                                if (physicalIndex === 0) {
+                                    UI.DOM.container.classList.add('no-transition');
+                                    UI.DOM.container.scrollTop = slidesData.length * viewHeight;
+                                    requestAnimationFrame(() => UI.DOM.container.classList.remove('no-transition'));
+                                } else if (physicalIndex === slidesData.length + 1) {
+                                    UI.DOM.container.classList.add('no-transition');
+                                    UI.DOM.container.scrollTop = viewHeight;
+                                    requestAnimationFrame(() => UI.DOM.container.classList.remove('no-transition'));
+                                }
+                            }, 50);
+                        }, { passive: true });
+                    });
+                }
             }
 
             function _initializePreloader() {
-                // To ensure the CSS transition is applied correctly after the initial render,
-                // we add the class inside a short timeout.
-                setTimeout(() => {
-                    UI.DOM.preloader.classList.add('content-visible');
-                }, 50); // A small delay to ensure the browser has painted the initial state.
-
-                // Add event listeners for the language buttons
-                const langSelection = UI.DOM.preloader.querySelector('.language-selection');
-                const languageButtons = langSelection.querySelectorAll('button');
-                languageButtons.forEach(button => {
-                    button.addEventListener('click', (event) => {
-                        const selectedLang = event.target.dataset.lang;
-                        _startApp(selectedLang);
+                setTimeout(() => UI.DOM.preloader.classList.add('content-visible'), 500);
+                UI.DOM.preloader.querySelectorAll('.language-selection button').forEach(button => {
+                    button.addEventListener('click', () => {
+                        UI.DOM.preloader.querySelectorAll('.language-selection button').forEach(btn => btn.disabled = true);
+                        button.classList.add('is-selected');
+                        setTimeout(() => _startApp(button.dataset.lang), 300);
                     }, { once: true });
                 });
             }

--- a/prosta-wersja/style.css
+++ b/prosta-wersja/style.css
@@ -209,22 +209,29 @@
         }
         #webyx-container {
             position: fixed;
-            top: var(--topbar-height);
+            top: 0;
             left: 0;
             width: 100%;
-            height: calc(100% - var(--topbar-height));
-            /* overflow, scroll-snap, and scroll-behavior are now controlled by Swiper.js */
+            height: 100%;
+            overflow-y: scroll;
+            scroll-snap-type: y mandatory;
+            scroll-behavior: smooth;
+            -webkit-overflow-scrolling: touch; /* For smooth scrolling on iOS */
             opacity: 0; /* Hidden initially */
             transition: opacity 0.5s linear;
+            scroll-padding: 0; /* PATCH: brak paddingu wpływającego na snap */
         }
         #webyx-container.ready {
             opacity: 1;
         }
         .webyx-section {
-            width: 100%; /* Let Swiper control width */
-            height: 100%; /* Let Swiper control height */
+            width: 100vw;
+            height: 100vh;
+            height: calc(var(--app-height) + 1px); /* PATCH: 1px na subpiksele */ /* Użycie zmiennej dla spójności */
             overflow: hidden;
             position: relative;
+            scroll-snap-align: start;
+            scroll-snap-stop: always; /* Zatrzymaj scroll-snap zawsze (nie pomijaj slajdów) */
             -webkit-transform: translate3d(0, 0, 0); /* Wymuś nową warstwę (zapobiega migotaniu) */
             transform: translate3d(0, 0, 0); /* Wymuś nową warstwę (zapobiega migotaniu) */
         }


### PR DESCRIPTION
Refactored the application to use a native CSS scroll-snap implementation for the video feed, replacing the Swiper.js library. This resolves a conflict that was causing the preloader to fail.

The preloader logic has also been replaced with a more robust version.

These changes were ported from a working prototype provided by the user to fix a persistent bug where the application would get stuck on the splash screen.