### PR TITLE
fix: Use <source> tag for video elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,19 +15,27 @@
         <div class="swiper-wrapper">
             <!-- Slides -->
             <div class="swiper-slide">
-                <video class="video-js" controls preload="auto" src="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4" loop muted playsinline></video>
+                <video class="video-js" controls preload="auto" loop muted playsinline>
+                    <source src="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4" type="video/mp4">
+                </video>
                 <div class="video-title">Big Buck Bunny</div>
             </div>
             <div class="swiper-slide">
-                <video class="video-js" controls preload="auto" src="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4" loop muted playsinline></video>
+                <video class="video-js" controls preload="auto" loop muted playsinline>
+                    <source src="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4" type="video/mp4">
+                </video>
                 <div class="video-title">Elephant Dream</div>
             </div>
             <div class="swiper-slide">
-                <video class="video-js" controls preload="auto" src="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerBlazes.mp4" loop muted playsinline></video>
+                <video class="video-js" controls preload="auto" loop muted playsinline>
+                    <source src="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerBlazes.mp4" type="video/mp4">
+                </video>
                 <div class="video-title">For Bigger Blazes</div>
             </div>
             <div class="swiper-slide">
-                <video class="video-js" controls preload="auto" src="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerEscapes.mp4" loop muted playsinline></video>
+                <video class="video-js" controls preload="auto" loop muted playsinline>
+                    <source src="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerEscapes.mp4" type="video/mp4">
+                </video>
                 <div class="video-title">For Bigger Escape</div>
             </div>
         </div>


### PR DESCRIPTION
- Updates the video elements in `index.html` to use a nested `<source>` tag instead of the `src` attribute.
- This is a more robust method for Video.js and resolves an issue where the player would incorrectly report the video format as unsupported.