### PR TITLE
Make videos fill the entire screen using object-fit: cover.

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
     <div id="splash-screen">
-        <button id="start-button">Rozpocznij ogladanie</button>
+        <button id="start-button">Rozpocznij</button>
     </div>
 
     <!-- Swiper -->

--- a/script.js
+++ b/script.js
@@ -19,7 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 controls: false, // Controls are hidden via CSS, but this is cleaner
                 autoplay: true, // Start muted and autoplay
                 muted: true, // Muted by default to allow autoplay
-                fluid: true, // Makes the player responsive
+                fluid: false, // We disable fluid mode to allow object-fit: cover
                 playsinline: true,
                 loop: true,
             });
@@ -50,10 +50,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // --- Initial Play ---
         // The first video should autoplay because of the `autoplay: true` option.
-        // We just need to ensure it's unmuted after the initial interaction.
+        // We will also explicitly play it and unmute it to ensure it starts.
         if (players.length > 0) {
             const activePlayer = players[swiper.realIndex];
             if (activePlayer) {
+                activePlayer.play().catch(error => console.error("Could not play video:", error));
                 activePlayer.muted(false); // Unmute the first video
             }
         }

--- a/style.css
+++ b/style.css
@@ -29,6 +29,11 @@ body, html {
     align-items: center;
 }
 
+.video-js {
+    width: 100%;
+    height: 100%;
+}
+
 .video-js .vjs-tech {
     width: 100%;
     height: 100%;
@@ -65,13 +70,3 @@ body, html {
 }
 
 /* --- Responsive Styles for Desktop --- */
-@media (min-width: 600px) {
-    .swiper {
-        height: 100vh;
-        width: calc(100vh * 9 / 16);
-        max-width: 100%;
-        margin: 0 auto;
-        border-left: 1px solid #333;
-        border-right: 1px solid #333;
-    }
-}


### PR DESCRIPTION
- Disable video.js fluid mode and adjust CSS to ensure the player fills the viewport.
- Videos now start with sound after the user clicks the "Start" button.
- Update start button text as requested.
- Remove desktop-specific styling to provide a consistent mobile-first experience.