### PR TITLE
feat: enforce 9:16 aspect ratio for video player

### DIFF
--- a/style.css
+++ b/style.css
@@ -21,12 +21,15 @@ body, html {
 
 /* This is the container I added inside the swiper-slide */
 .video-slide {
-    width: 100vw;
-    height: 100vh;
+    width: 100%;
+    height: 100%;
+    max-width: calc(100vh * (9 / 16));
+    margin: 0 auto;
     position: relative;
     display: flex;
     justify-content: center;
     align-items: center;
+    background-color: #111;
 }
 
 .video-js {


### PR DESCRIPTION
This change modifies the CSS to ensure that the video player container always maintains a 9:16 aspect ratio, similar to a mobile app like TikTok.

On wider screens (like desktop), the video player will be centered with letterboxing on the sides. On screens that are already in a portrait aspect ratio, the player will fill the screen.

This is achieved by setting a `max-width` on the `.video-slide` container that is calculated based on the viewport height.