### PR TITLE
feat: Enforce 9:16 aspect ratio for videos on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -20,6 +20,7 @@ body, html {
 }
 
 /* This is the container I added inside the swiper-slide */
+/* Default styles for screens wider than 9:16 (desktop) */
 .video-slide {
     width: 100%;
     height: 100%;
@@ -30,6 +31,17 @@ body, html {
     justify-content: center;
     align-items: center;
     background-color: #111;
+}
+
+/* For screens with aspect ratio of 9:16 or narrower (phones) */
+@media (max-aspect-ratio: 9/16) {
+    .video-slide {
+        width: 100%;
+        max-width: 100%;
+        height: calc(100vw * 16 / 9);
+        margin-top: auto;
+        margin-bottom: auto;
+    }
 }
 
 .video-js {


### PR DESCRIPTION
The previous CSS implementation did not correctly handle video aspect ratios on mobile devices with screens taller than 16:9. The video container would stretch to the full height of the device, resulting in an incorrect aspect ratio and causing the video content to be improperly cropped.

This change introduces a CSS media query to detect screens with an aspect ratio of 9/16 or narrower (typical of mobile phones in portrait mode). For these screens, the video container's height is now calculated based on its width to strictly enforce a 9:16 aspect ratio.

This ensures that videos are always displayed in the intended format, centered on the screen, on all devices.