### PR TITLE
The main layout, including the top bar, sidebar, and bottom bar, was …

### DIFF
--- a/style.css
+++ b/style.css
@@ -206,7 +206,7 @@
             width: 100%;
             height: 100%;
             object-fit: cover;
-            z-index: 10;
+            z-index: -1;
             background:transparent;
             opacity:1;
             transition: opacity 0.3s ease, filter 0.3s ease; /* Add filter transition */


### PR DESCRIPTION
…not visible because it was rendered underneath the video player.

This was caused by the video element having a positive z-index while being a sibling to the other UI components within the same stacking context.

The fix involves changing the z-index of the video element to -1, which places it at the bottom of the stacking context, ensuring all other UI elements are rendered on top of it.