### PR TITLE
Fix: Make language selection buttons functional

### DIFF
--- a/index.html
+++ b/index.html
@@ -3762,13 +3762,28 @@
 
             function _initializePreloader() {
                 setTimeout(() => UI.DOM.preloader.classList.add('content-visible'), 500);
-                UI.DOM.preloader.querySelectorAll('.language-selection button').forEach(button => {
-                    button.addEventListener('click', () => {
-                        UI.DOM.preloader.querySelectorAll('.language-selection button').forEach(btn => btn.disabled = true);
-                        button.classList.add('is-selected');
-                        setTimeout(() => _startApp(button.dataset.lang), 300);
-                    }, { once: true });
-                });
+                const langButtonsContainer = UI.DOM.preloader.querySelector('.language-selection .lang-buttons-container');
+                if (!langButtonsContainer) return;
+
+                const langSelectHandler = (event) => {
+                    const button = event.target.closest('button[data-lang]');
+                    if (!button || button.disabled) {
+                        return;
+                    }
+
+                    // Remove listener to emulate { once: true } behavior and prevent multiple triggers
+                    langButtonsContainer.removeEventListener('click', langSelectHandler);
+
+                    // Disable all buttons
+                    langButtonsContainer.querySelectorAll('button').forEach(btn => {
+                        btn.disabled = true;
+                    });
+
+                    button.classList.add('is-selected');
+                    setTimeout(() => _startApp(button.dataset.lang), 300);
+                };
+
+                langButtonsContainer.addEventListener('click', langSelectHandler);
             }
 
             function _setInitialConfig() {


### PR DESCRIPTION
The language selection buttons in the preloader were not starting the application. This was due to the way the click event listeners were attached, which was not robust enough to handle clicks on child elements within the buttons.

This change refactors the event handling to use event delegation. A single click listener is now attached to the button container, which correctly identifies the clicked button and initiates the application startup sequence. This makes the language selection functionality more reliable.