### PR TITLE
refactor: Make topbar a global fixed element

### DIFF
--- a/index.html
+++ b/index.html
@@ -352,14 +352,14 @@
         .videoPlayer.secret-active {
             filter: blur(12px) saturate(120%);
         }
-        .tiktok-symulacja .topbar,
+        .topbar,
         .tiktok-symulacja .bottombar,
-        .tiktok-symulacja .login-panel {
+        .login-panel {
             background: rgba(0, 0, 0, 0.6);
             -webkit-backdrop-filter: blur(8px);
             backdrop-filter: blur(8px);
         }
-        .tiktok-symulacja .topbar {
+        .topbar {
             position: fixed;
             display: flex;
             justify-content: center; /* Center the middle element */
@@ -370,29 +370,29 @@
             width: 100%;
             height: var(--topbar-height);
             padding-top: var(--safe-area-top);
-            z-index: 15;
+            z-index: 115;
             padding: 0;
             font: inherit;
             color: inherit;
             border-bottom: 1px solid rgba(255, 255, 255, 0.15); /* Subtle separator */
             transition: border-color 0.3s ease-out;
         }
-        .tiktok-symulacja .topbar.login-panel-active {
+        .topbar.login-panel-active {
             border-bottom-color: transparent;
         }
-        .tiktok-symulacja .topbar.login-panel-active .central-text-wrapper.with-arrow::after {
+        .topbar.login-panel-active .central-text-wrapper.with-arrow::after {
             transform: translateY(-50%) rotate(180deg);
         }
-        .tiktok-symulacja .central-text-wrapper {
+        .central-text-wrapper {
             position: relative;
         }
-        .tiktok-symulacja .topbar-text {
+        .topbar-text {
             font-size: 14px;
             font-weight: 500;
             color: white;
             pointer-events: none;
         }
-        .tiktok-symulacja .central-text-wrapper.with-arrow::after {
+        .central-text-wrapper.with-arrow::after {
             content: '▼';
             position: absolute;
             left: 100%;
@@ -594,7 +594,7 @@
         .tiktok-symulacja .icon-button.force-active .icon-label {
             color: white !important;
         }
-        .tiktok-symulacja .topbar-central-trigger {
+        .topbar-central-trigger {
             background: none;
             border: none;
             padding: 0;
@@ -605,10 +605,10 @@
             display: flex;
             justify-content: center;
         }
-        .tiktok-symulacja .topbar-central-trigger:active {
+        .topbar-central-trigger:active {
             transform: scale(0.98);
         }
-        .tiktok-symulacja .topbar-icon-btn {
+        .topbar-icon-btn {
             position: absolute;
             background: none;
             border: none;
@@ -624,31 +624,31 @@
             top: 50%;
             transform: translateY(-50%);
         }
-        .tiktok-symulacja .hamburger-icon {
+        .hamburger-icon {
             left: 0;
         }
-        .tiktok-symulacja .notification-bell {
+        .notification-bell {
             right: 0;
         }
-        .tiktok-symulacja .topbar-icon-btn:active:not([disabled]) {
+        .topbar-icon-btn:active:not([disabled]) {
             transform: translateY(-50%) scale(0.9);
         }
-        .tiktok-symulacja .topbar-icon-btn[disabled] {
+        .topbar-icon-btn[disabled] {
             opacity: 0.5;
             cursor: not-allowed;
             transform: translateY(-50%) scale(1);
         }
-        .tiktok-symulacja .hamburger-icon svg {
+        .hamburger-icon svg {
             stroke: white;
             stroke-width: 2.5;
             stroke-linecap: round;
             fill: none;
         }
-        .tiktok-symulacja .notification-bell svg {
+        .notification-bell svg {
             stroke: white;
             fill: none;
         }
-        .tiktok-symulacja .notification-dot {
+        .notification-dot {
             position: absolute;
             top: 10px;
             right: 11px;
@@ -662,7 +662,7 @@
         /* ==========================================================================
            --- KOMPONENTY UI: PANELE I MENU ---
            ========================================================================== */
-        .tiktok-symulacja .login-panel {
+        .login-panel {
             position: absolute;
             top: var(--topbar-height);
             left: 0;
@@ -674,21 +674,21 @@
             z-index: 110 !important;
             border-top: none; /* Ensure no top border */
         }
-        .tiktok-symulacja .login-panel.active {
+        .login-panel.active {
             max-height: 500px;
         }
-        .tiktok-symulacja .login-panel > div {
+        .login-panel > div {
             padding: 20px 25px;
             background: transparent !important;
         }
-        .tiktok-symulacja .login-panel form {
+        .login-panel form {
             margin-bottom: 0 !important;
             padding-bottom: 0 !important;
             display: flex;
             flex-direction: column;
             gap: 8px;
         }
-        .tiktok-symulacja .login-panel form p {
+        .login-panel form p {
             margin: 0;
         }
 
@@ -726,7 +726,7 @@
             background: #222;
         }
 
-        .tiktok-symulacja .logged-in-menu {
+        .logged-in-menu {
             position: absolute;
             top: var(--topbar-height);
             left: 0;
@@ -742,10 +742,10 @@
             flex-direction: column;
             border: none; /* Removed border */
         }
-        .tiktok-symulacja .logged-in-menu.active {
+        .logged-in-menu.active {
             max-height: 200px;
         }
-        .tiktok-symulacja .logged-in-menu a {
+        .logged-in-menu a {
             color: white;
             text-decoration: none;
             padding: 12px 24px 12px 16px;
@@ -755,11 +755,11 @@
             border-bottom: 1px solid rgba(255, 255, 255, 0.1);
             transition: background-color 0.2s ease;
         }
-        .tiktok-symulacja .logged-in-menu a:last-child {
+        .logged-in-menu a:last-child {
             border-bottom: none;
         }
-        .tiktok-symulacja .logged-in-menu a:hover,
-        .tiktok-symulacja .logged-in-menu a:focus {
+        .logged-in-menu a:hover,
+        .logged-in-menu a:focus {
             background: rgba(255, 255, 255, 0.1);
             outline: none;
         }
@@ -1897,6 +1897,21 @@
             </div>
         </div>
     </div>
+
+    <!-- Global UI Elements -->
+    <div class="topbar" data-view="default">
+        <button class="topbar-icon-btn hamburger-icon" data-action="toggle-main-menu" data-translate-aria-label="menuAriaLabel" aria-label="Menu"><svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true"><path d="M3 12h18M3 6h18M3 18h18"></path></svg></button>
+        <button class="topbar-central-trigger" data-action="toggle-login-panel"><div class="central-text-wrapper"><span class="topbar-text"></span></div></button>
+        <button class="topbar-icon-btn notification-bell" data-action="toggle-notifications" data-translate-aria-label="notificationAriaLabel" aria-label="Powiadomienia"><svg viewBox="0 0 24 24" width="22" height="22" aria-hidden="true"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M13.73 21a2 2 0 0 1-3.46 0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg><div class="notification-dot"></div></button>
+    </div>
+    <div class="login-panel" aria-hidden="true">
+        <!-- Content will be injected by JS -->
+    </div>
+    <div class="logged-in-menu" aria-hidden="true">
+        <a href="#" data-action="open-account-modal" class="accountMenuButton" data-translate-key="accountMenuButton">Konto</a>
+        <a href="#" data-action="logout" class="logout-link" data-translate-key="logoutLink">Wyloguj</a>
+    </div>
+
     <!-- Szablon dla pojedynczego slajdu -->
     <template id="slide-template">
         <div class="webyx-section swiper-slide">
@@ -1912,18 +1927,6 @@
                     <svg class="secret-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 00-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" /></svg>
                     <h2 class="secret-title" data-translate-key="secretTitle">Top Secret</h2>
                     <p class="secret-subtitle" data-translate-key="secretSubtitle">Log in to unlock</p>
-                </div>
-                <div class="topbar" data-view="default">
-                    <button class="topbar-icon-btn hamburger-icon" data-action="toggle-main-menu" data-translate-aria-label="menuAriaLabel" aria-label="Menu"><svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true"><path d="M3 12h18M3 6h18M3 18h18"></path></svg></button>
-                    <button class="topbar-central-trigger" data-action="toggle-login-panel"><div class="central-text-wrapper"><span class="topbar-text"></span></div></button>
-                    <button class="topbar-icon-btn notification-bell" data-action="toggle-notifications" data-translate-aria-label="notificationAriaLabel" aria-label="Powiadomienia"><svg viewBox="0 0 24 24" width="22" height="22" aria-hidden="true"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M13.73 21a2 2 0 0 1-3.46 0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg><div class="notification-dot"></div></button>
-                </div>
-                <div class="login-panel" aria-hidden="true">
-                    <!-- Content will be injected by JS -->
-                </div>
-                <div class="logged-in-menu" aria-hidden="true">
-                    <a href="#" data-action="open-account-modal" class="accountMenuButton" data-translate-key="accountMenuButton">Konto</a>
-                    <a href="#" data-action="logout" class="logout-link" data-translate-key="logoutLink">Wyloguj</a>
                 </div>
                 <div class="sidebar">
                     <div class="profile">
@@ -2677,6 +2680,24 @@
                 const isLoggedIn = State.get('isUserLoggedIn');
                 const currentSlideIndex = State.get('currentSlideIndex');
 
+                // Update global UI elements
+                const topbar = document.querySelector('body > .topbar');
+                const loginPanel = document.querySelector('body > .login-panel');
+                const loggedInMenu = document.querySelector('body > .logged-in-menu');
+
+                if (topbar) {
+                    topbar.querySelector('.central-text-wrapper').classList.toggle('with-arrow', !isLoggedIn);
+                    topbar.querySelector('.topbar-text').textContent = isLoggedIn ? Utils.getTranslation('loggedInText') : Utils.getTranslation('loggedOutText');
+                    topbar.classList.remove('login-panel-active');
+                }
+                if (loginPanel) {
+                    loginPanel.classList.remove('active');
+                }
+                if(loggedInMenu) {
+                    loggedInMenu.classList.remove('active');
+                }
+
+                // Update per-slide elements
                 DOM.container.querySelectorAll('.webyx-section').forEach((section) => {
                     const sim = section.querySelector('.tiktok-symulacja');
                     sim.classList.toggle('is-logged-in', isLoggedIn);
@@ -2685,11 +2706,6 @@
 
                     section.querySelector('.secret-overlay').classList.toggle('visible', showSecretOverlay);
                     section.querySelector('.videoPlayer').classList.toggle('secret-active', showSecretOverlay);
-                    section.querySelector('.topbar .central-text-wrapper').classList.toggle('with-arrow', !isLoggedIn);
-                    section.querySelector('.login-panel').classList.remove('active');
-                    section.querySelector('.topbar').classList.remove('login-panel-active');
-                    section.querySelector('.logged-in-menu').classList.remove('active');
-                    section.querySelector('.topbar .topbar-text').textContent = isLoggedIn ? Utils.getTranslation('loggedInText') : Utils.getTranslation('loggedOutText');
 
                     const likeBtn = section.querySelector('.like-button');
                     if (likeBtn) {
@@ -2720,21 +2736,6 @@
                 section.dataset.index = index;
                 section.dataset.slideId = slideData.id;
 
-                const loginPanel = section.querySelector('.login-panel');
-                const renderedForm = document.getElementById('um-login-render-container');
-                if (loginPanel && renderedForm) {
-                    loginPanel.innerHTML = renderedForm.innerHTML;
-                    const form = loginPanel.querySelector('.login-form');
-                    if (form) {
-                        form.querySelector('label[for="user_login"]')?.remove();
-                        form.querySelector('#user_login')?.setAttribute('placeholder', 'Login');
-                        form.querySelector('label[for="user_pass"]')?.remove();
-                        form.querySelector('#user_pass')?.setAttribute('placeholder', 'Hasło');
-                        const submitButton = form.querySelector('#wp-submit');
-                        if (submitButton) submitButton.value = 'ENTER';
-                    }
-                }
-
                 section.querySelector('.tiktok-symulacja').dataset.access = slideData.access;
                 section.querySelector('.videoPlayer').poster = slideData.poster || Config.LQIP_POSTER;
                 section.querySelector('.profileButton img').src = slideData.avatar;
@@ -2763,6 +2764,23 @@
                 });
             }
 
+            function initGlobalPanels() {
+                const loginPanel = document.querySelector('body > .login-panel');
+                const renderedForm = document.getElementById('um-login-render-container');
+                if (loginPanel && renderedForm) {
+                    loginPanel.innerHTML = renderedForm.innerHTML;
+                    const form = loginPanel.querySelector('.login-form');
+                    if (form) {
+                        form.querySelector('label[for="user_login"]')?.remove();
+                        form.querySelector('#user_login')?.setAttribute('placeholder', 'Login');
+                        form.querySelector('label[for="user_pass"]')?.remove();
+                        form.querySelector('#user_pass')?.setAttribute('placeholder', 'Hasło');
+                        const submitButton = form.querySelector('#wp-submit');
+                        if (submitButton) submitButton.value = 'ENTER';
+                    }
+                }
+            }
+
             return {
                 DOM,
                 showAlert,
@@ -2771,7 +2789,8 @@
                 updateUIForLoginState,
                 updateTranslations,
                 applyLikeStateToDom,
-                renderSlides
+                renderSlides,
+                initGlobalPanels
             };
         })();
 
@@ -3171,7 +3190,10 @@
                     }
 
                     const action = actionTarget.dataset.action;
-                    const section = actionTarget.closest('.webyx-section');
+
+                    const topbar = document.querySelector('body > .topbar');
+                    const loginPanel = document.querySelector('body > .login-panel');
+                    const loggedInMenu = document.querySelector('body > .logged-in-menu');
 
                     switch (action) {
                         case 'toggle-like': handleLikeToggle(actionTarget); break;
@@ -3180,16 +3202,19 @@
                         case 'open-comments-modal': UI.openModal(UI.DOM.commentsModal); break;
                         case 'open-info-modal': UI.openModal(UI.DOM.infoModal); break;
                         case 'open-account-modal':
-                            if(section) section.querySelector('.logged-in-menu').classList.remove('active');
+                            if (loggedInMenu) loggedInMenu.classList.remove('active');
                             AccountPanel.openAccountModal();
                             break;
                         case 'close-account-modal':
                             AccountPanel.closeAccountModal();
                             break;
-                        case 'logout': e.preventDefault(); handleLogout(actionTarget); break;
+                        case 'logout':
+                            e.preventDefault();
+                            handleLogout(actionTarget);
+                            break;
                         case 'toggle-main-menu':
                             if (State.get('isUserLoggedIn')) {
-                                section.querySelector('.logged-in-menu').classList.toggle('active');
+                                if (loggedInMenu) loggedInMenu.classList.toggle('active');
                             } else {
                                 Utils.vibrateTry();
                                 UI.showAlert(Utils.getTranslation('menuAccessAlert'));
@@ -3197,8 +3222,8 @@
                             break;
                         case 'toggle-login-panel':
                             if (!State.get('isUserLoggedIn')) {
-                                section.querySelector('.login-panel').classList.toggle('active');
-                                section.querySelector('.topbar').classList.toggle('login-panel-active');
+                                if (loginPanel) loginPanel.classList.toggle('active');
+                                if (topbar) topbar.classList.toggle('login-panel-active');
                             }
                             break;
                         case 'subscribe':
@@ -3790,6 +3815,7 @@
                     _setInitialConfig();
                     _initializeGlobalListeners();
                     AccountPanel.init();
+                    UI.initGlobalPanels();
                     _initializePreloader();
                     document.body.classList.add('loaded');
                 },


### PR DESCRIPTION
Moved the topbar, login panel, and user menu out of the Swiper.js slide template and into the main body to create a single, global instance of these elements.

Updated JavaScript to reference and control these new global elements, removing the logic that targeted per-slide instances.

Adjusted CSS selectors to apply styles correctly to the refactored global elements, ensuring the topbar is fixed to the viewport (`position: fixed`) and does not scroll with the slides.

This change addresses the user's request for a persistent navigation bar that remains visible at all times.