### PR TITLE
Add responsive layout for wide screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -1791,6 +1791,17 @@
             outline-offset: 2px;
         }
         .vjs-has-started .vjs-poster { display: none; }
+
+        @media (min-width: 600px) {
+            #webyx-container {
+                height: 100vh;
+                width: calc(100vh * 9 / 16);
+                max-width: 100%;
+                margin: 0 auto;
+                border-left: 1px solid #333;
+                border-right: 1px solid #333;
+            }
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
This change introduces CSS rules to display the application in a vertical, phone-like layout on screens wider than 600px.

The main container is centered with black bars on the sides, simulating a mobile view on desktops and tablets.