### PR TITLE
Replaced incorrect CSS for `#app-frame` with new rules targeting `#we…

### DIFF
--- a/index.html
+++ b/index.html
@@ -1799,7 +1799,7 @@
                 justify-content: center;
                 background-color: #111;
             }
-            #app-frame {
+            #webyx-container {
                 position: relative;
                 height: 100vh;
                 width: calc(100vh * 9 / 16);
@@ -1810,13 +1810,6 @@
                 border-right: 1px solid #333;
                 overflow: hidden;
                 box-shadow: 0 0 20px rgba(0,0,0,0.5);
-            }
-            #webyx-container {
-                width: 100%;
-                height: 100%;
-            }
-            .topbar {
-                position: absolute;
             }
         }
     </style>


### PR DESCRIPTION
…byx-container` directly. This change fixes the layout on screens wider than 600px, ensuring the content is properly centered with a 9:16 aspect ratio.