### PR TITLE
Fix: Align topbar width with main container on wide screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -1811,6 +1811,14 @@
                 overflow: hidden;
                 box-shadow: 0 0 20px rgba(0,0,0,0.5);
             }
+            .topbar {
+                width: calc(100vh * 9 / 16);
+                max-width: 100%;
+                left: 50%;
+                transform: translateX(-50%);
+                border-left: 1px solid #333;
+                border-right: 1px solid #333;
+            }
         }
     </style>
 </head>


### PR DESCRIPTION
On wider screens, the topbar previously spanned the full viewport width, while the main content was centered in a container. This created a visual inconsistency.

This change modifies the CSS for the `.topbar` element within the `(min-width: 600px)` media query. It sets the topbar's width to match the main content container and centers it horizontally. This ensures the topbar is visually aligned and consistent with the main feed on larger devices.