### PR TITLE
Fix: Center application layout on wide screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -1799,7 +1799,7 @@
                 justify-content: center;
                 background-color: #111;
             }
-            #webyx-container {
+            #app-frame {
                 position: relative;
                 height: 100vh;
                 width: calc(100vh * 9 / 16);
@@ -1810,6 +1810,10 @@
                 border-right: 1px solid #333;
                 overflow: hidden;
                 box-shadow: 0 0 20px rgba(0,0,0,0.5);
+            }
+            #webyx-container {
+                width: 100%;
+                height: 100%;
             }
             .topbar {
                 width: calc(100vh * 9 / 16);


### PR DESCRIPTION
The application layout was not correctly centered on screens wider than 600px. The top bar and other UI elements appeared outside the main content frame.

This was caused by the container styles being applied to `#webyx-container` instead of the main `#app-frame` wrapper.

This commit moves the framing, sizing, and centering styles from `#webyx-container` to `#app-frame` within the `@media (min-width: 600px)` block. This ensures that the entire application interface is correctly contained within a single, centered frame on wide screens, as intended.