### PR TITLE
Fix: Add defer attribute to script tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -353,14 +353,8 @@
     <input type="file" class="file-input" id="avatarFileInput" accept="image/*">
     <div id="um-login-render-container" style="display: none;">[tt_login_form]</div>
 
-    <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
-    <script src="https://vjs.zencdn.net/8.23.3/video.min.js"></script>
-
-    <script id="tt-patch-2025-08-18">
-    // ... (kod skryptu) ...
-    </script>
-    <script>
-    // ... (kod skryptu) ...
-    </script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js" defer></script>
+    <script src="https://vjs.zencdn.net/8.23.3/video.min.js" defer></script>
+    <script src="script.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
This commit fixes a bug where the language selection panel was not being displayed during the preloading sequence.

The issue was caused by the refactoring that moved the scripts into an external file (`script.js`) and loaded it from the `<head>`. The `<script>` tag was missing the `defer` attribute, which caused the script to execute before the HTML document was fully parsed. As a result, the JavaScript code could not find the `#preloader` element in the DOM and failed to make the language panel visible.

The fix adds the `defer` attribute to all `<script>` tags in `index.html` to ensure they only execute after the DOM is ready.