### PR TITLE
Fix: Language selection panel not displaying

### DIFF
--- a/script.js
+++ b/script.js
@@ -1435,7 +1435,7 @@
             }
 
             function _initializePreloader() {
-                setTimeout(() => UI.DOM.preloader.classList.add('content-visible'), 500);
+                UI.DOM.preloader.classList.add('content-visible');
                 UI.DOM.preloader.querySelectorAll('.language-selection button').forEach(button => {
                     button.addEventListener('click', () => {
                         UI.DOM.preloader.querySelectorAll('.language-selection button').forEach(btn => btn.disabled = true);


### PR DESCRIPTION
The language selection panel, located within the preloader, was not appearing because its visibility was being triggered inside a `setTimeout`.

This introduced a potential race condition or timing issue, preventing the panel from reliably displaying.

The fix removes the `setTimeout` to make the panel's visibility update synchronous and immediate, ensuring it appears as expected during application initialization.