### PR TITLE
Fix language panel not loading on startup.

### DIFF
--- a/script.js
+++ b/script.js
@@ -1121,15 +1121,33 @@
                     });
                 }
 
-                document.getElementById('zoomSlider').addEventListener('input', function() {
-                    scale = parseFloat(this.value);
-                    drawCropCanvas();
-                });
+                const zoomSlider = document.getElementById('zoomSlider');
+                if (zoomSlider) {
+                    zoomSlider.addEventListener('input', function() {
+                        scale = parseFloat(this.value);
+                        drawCropCanvas();
+                    });
+                }
 
-                document.getElementById('cropCloseBtn').addEventListener('click', closeCropModal);
-                document.getElementById('zoomInBtn').addEventListener('click', () => adjustZoom(0.1));
-                document.getElementById('zoomOutBtn').addEventListener('click', () => adjustZoom(-0.1));
-                document.getElementById('cropSaveBtn').addEventListener('click', cropAndSave);
+                const cropCloseBtn = document.getElementById('cropCloseBtn');
+                if (cropCloseBtn) {
+                    cropCloseBtn.addEventListener('click', closeCropModal);
+                }
+
+                const zoomInBtn = document.getElementById('zoomInBtn');
+                if (zoomInBtn) {
+                    zoomInBtn.addEventListener('click', () => adjustZoom(0.1));
+                }
+
+                const zoomOutBtn = document.getElementById('zoomOutBtn');
+                if (zoomOutBtn) {
+                    zoomOutBtn.addEventListener('click', () => adjustZoom(-0.1));
+                }
+
+                const cropSaveBtn = document.getElementById('cropSaveBtn');
+                if (cropSaveBtn) {
+                    cropSaveBtn.addEventListener('click', cropAndSave);
+                }
 
                 document.addEventListener('keydown', function(event) {
                     if (event.key === 'Escape') {


### PR DESCRIPTION
The language selection panel was not appearing because of a fatal JavaScript error that halted script execution.

An error occurred in the AccountPanel module when trying to add event listeners to crop-modal elements that do not exist in the initial DOM. This crash prevented the _initializePreloader function from being called.

Guarded the event listener attachments in the AccountPanel's setupEventListeners function with null checks. This prevents the script from crashing and allows the application to initialize correctly, including the language panel.