### PR TITLE
feat: PWA install prompt as a bottom bar overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,6 +140,13 @@
                 </div>
         </div>
     </div>
+    <div id="pwaInstallPrompt" class="pwa-install-prompt-banner" aria-hidden="true">
+        <div>
+            <h3 data-translate-key="installPwaTitle">Zainstaluj aplikację!</h3>
+            <p data-translate-key="installPwaDescription">Uzyskaj pełne wrażenia. Zainstaluj aplikację Ting Tong na swoim urządzeniu.</p>
+        </div>
+        <button class="btn-primary" data-action="install-pwa" data-translate-key="installAppText">Zainstaluj</button>
+    </div>
     <div id="alertBox" role="status" aria-live="polite">
         <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" style="width:18px; height:18px; stroke:white; stroke-width:2; fill:none; margin-right:6px;"><path d="M6 10V8a6 6 0 1 1 12 0v2" /><rect x="4" y="10" width="16" height="10" rx="2" ry="2" /></svg>
         <span id="alertText"></span>
@@ -369,14 +376,6 @@
                 <img src="/qr-code-placeholder.png" alt="QR Code" width="128" height="128">
             </div>
         </div>
-    </div>
-
-    <div id="pwaInstallPrompt" class="pwa-install-prompt-banner" aria-hidden="true">
-        <div>
-            <h3 data-translate-key="installPwaTitle">Zainstaluj aplikację!</h3>
-            <p data-translate-key="installPwaDescription">Uzyskaj pełne wrażenia. Zainstaluj aplikację Ting Tong na swoim urządzeniu.</p>
-        </div>
-        <button class="btn-primary" data-action="install-pwa" data-translate-key="installAppText">Zainstaluj</button>
     </div>
 
     <div id="pwaIosInstructions" class="modal-overlay" aria-hidden="true" role="dialog" aria-modal="true">

--- a/script.js
+++ b/script.js
@@ -1546,7 +1546,8 @@ const PWA = (function() {
         window.addEventListener('beforeinstallprompt', (e) => {
             e.preventDefault();
             installPromptEvent = e;
-            if (!isIOS() && !isDesktop()) {
+            // Show the prompt banner if the event was fired.
+            if (DOM.pwaInstallPrompt) {
                 DOM.pwaInstallPrompt.classList.add('visible');
             }
         });

--- a/style.css
+++ b/style.css
@@ -1784,11 +1784,13 @@
 }
 /* --- Style dla promptu na mobilnym (PWAInstallPrompt.tsx) --- */
 .pwa-install-prompt-banner {
-    position: fixed;
+    position: absolute;
     bottom: 0;
     left: 0;
     width: 100%;
-    background: #2d2d2d;
+    background: rgba(45, 45, 45, 0.9);
+    -webkit-backdrop-filter: blur(10px);
+    backdrop-filter: blur(10px);
     color: white;
     padding: 16px;
     display: flex;
@@ -1797,15 +1799,19 @@
     align-items: center;
     text-align: left;
     gap: 16px;
-    z-index: 9999;
-    height: var(--bottombar-base-height);
-    padding-bottom: calc(1.5rem + var(--safe-area-bottom));
+    z-index: 110; /* Higher than bottombar's 105 */
+    height: var(--bottombar-height);
+    padding-bottom: calc(16px + var(--safe-area-bottom)); /* Adjust padding to account for safe area */
     transform: translateY(100%);
-    transition: transform 0.3s ease-out;
+    transition: transform 0.3s ease-out, opacity 0.3s ease-out;
+    opacity: 0;
+    pointer-events: none;
 }
 
 .pwa-install-prompt-banner.visible {
     transform: translateY(0);
+    opacity: 1;
+    pointer-events: auto;
 }
 
 .pwa-install-prompt-banner h3 {


### PR DESCRIPTION
Refactors the PWA installation prompt to be a bar that overlays the bottom navigation bar.

- The prompt is now a bar with the same height as the bottom bar.
- It contains a message and an "Install" button.
- The prompt is only displayed on devices that support PWA installation and only if the app is not already installed.
- The HTML structure was updated to make the prompt a global element within the app frame.
- CSS was adjusted to position the prompt as an overlay.
- JavaScript logic was simplified to show the prompt whenever the `beforeinstallprompt` event is fired, relying on the existing `isStandalone` check to prevent it from showing in an installed PWA.