### PR TITLE
fix: Correctly position PWA install prompt

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,13 +139,13 @@
             <div class="swiper-wrapper">
                 </div>
         </div>
-    </div>
-    <div id="pwaInstallPrompt" class="pwa-install-prompt-banner" aria-hidden="true">
-        <div>
-            <h3 data-translate-key="installPwaTitle">Zainstaluj aplikację!</h3>
-            <p data-translate-key="installPwaDescription">Uzyskaj pełne wrażenia. Zainstaluj aplikację Ting Tong na swoim urządzeniu.</p>
+        <div id="pwaInstallPrompt" class="pwa-install-prompt-banner" aria-hidden="true">
+            <div>
+                <h3 data-translate-key="installPwaTitle">Zainstaluj aplikację!</h3>
+                <p data-translate-key="installPwaDescription">Uzyskaj pełne wrażenia. Zainstaluj aplikację Ting Tong na swoim urządzeniu.</p>
+            </div>
+            <button class="btn-primary" data-action="install-pwa" data-translate-key="installAppText">Zainstaluj</button>
         </div>
-        <button class="btn-primary" data-action="install-pwa" data-translate-key="installAppText">Zainstaluj</button>
     </div>
     <div id="alertBox" role="status" aria-live="polite">
         <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" style="width:18px; height:18px; stroke:white; stroke-width:2; fill:none; margin-right:6px;"><path d="M6 10V8a6 6 0 1 1 12 0v2" /><rect x="4" y="10" width="16" height="10" rx="2" ry="2" /></svg>


### PR DESCRIPTION
This commit fixes a bug in the PWA installation prompt feature where the prompt bar was not correctly positioned.

The `#pwaInstallPrompt` element was previously placed outside the main `#app-frame` container, causing it to be positioned relative to the viewport instead of the app's UI. This resulted in the bar not being visible or appearing in the wrong location.

The fix moves the `#pwaInstallPrompt` element to be the last child of the `#app-frame` div, ensuring it is positioned correctly as an overlay on top of the bottom navigation bar.