### PR TITLE
feat: Implement PWA install prompt based on reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,13 +139,6 @@
             <div class="swiper-wrapper">
                 </div>
         </div>
-        <div id="pwaInstallPrompt" class="pwa-install-prompt-banner" aria-hidden="true">
-            <div>
-                <h3 data-translate-key="installPwaTitle">Zainstaluj aplikację!</h3>
-                <p data-translate-key="installPwaDescription">Uzyskaj pełne wrażenia. Zainstaluj aplikację Ting Tong na swoim urządzeniu.</p>
-            </div>
-            <button class="btn-primary" data-action="install-pwa" data-translate-key="installAppText">Zainstaluj</button>
-        </div>
     </div>
     <div id="alertBox" role="status" aria-live="polite">
         <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" style="width:18px; height:18px; stroke:white; stroke-width:2; fill:none; margin-right:6px;"><path d="M6 10V8a6 6 0 1 1 12 0v2" /><rect x="4" y="10" width="16" height="10" rx="2" ry="2" /></svg>
@@ -367,26 +360,23 @@
     <input type="file" class="file-input" id="avatarFileInput" accept="image/*">
     <div id="um-login-render-container" style="display: none;">[tt_login_form]</div>
 
-    <div id="pwaDesktopModal" class="modal-overlay" aria-hidden="true" role="dialog" aria-modal="true">
-        <div class="modal-content" tabindex="-1">
-            <button class="modal-close-btn" data-action="close-modal" aria-label="Zamknij">&times;</button>
-            <h3 data-translate-key="pwaModalTitle"></h3>
-            <p data-translate-key="pwaModalBody"></p>
-            <div class="qr-code-container">
-                <img src="/qr-code-placeholder.png" alt="QR Code" width="128" height="128">
-            </div>
+    <div id="pwa-install-bar" class="pwa-prompt hidden">
+        <div class="pwa-prompt-content">
+            <h3 class="pwa-prompt-title">Zainstaluj aplikację!</h3>
+            <p class="pwa-prompt-description">Dodaj Ting Tong do ekranu głównego, aby mieć szybki dostęp.</p>
         </div>
+        <button id="pwa-install-button" class="pwa-prompt-button">Zainstaluj</button>
     </div>
 
-    <div id="pwaIosInstructions" class="modal-overlay" aria-hidden="true" role="dialog" aria-modal="true">
-        <div class="modal-content" tabindex="-1">
-            <button class="modal-close-btn" data-action="close-modal" aria-label="Zamknij">&times;</button>
-            <h3 data-translate-key="installPwaTitle"></h3>
-            <p data-translate-key="pwaIosInstruction1"></p>
-            <img src="/icons/share-ios.svg" alt="Ikona Udostępniania">
-            <p data-translate-key="pwaIosInstruction2"></p>
-            <img src="/icons/add-to-home.svg" alt="Ikona Dodawania">
-            <p data-translate-key="pwaIosInstruction3"></p>
+    <div id="pwa-ios-instructions" class="pwa-prompt-ios hidden">
+        <div class="pwa-ios-header">
+            <h3>Jak zainstalować aplikację</h3>
+            <button id="pwa-ios-close-button" class="pwa-ios-close-button">&times;</button>
+        </div>
+        <div class="pwa-ios-body">
+            <p>1. Stuknij ikonę <strong>udostępniania</strong> w przeglądarce.</p>
+            <p>2. Wybierz <strong>"Dodaj do ekranu początkowego"</strong>.</p>
+            <p>3. Potwierdź, a aplikacja pojawi się na Twoim ekranie!</p>
         </div>
     </div>
     <script>

--- a/style.css
+++ b/style.css
@@ -1763,112 +1763,83 @@
     }
 }
 
-/* --- Styl dla przycisku desktopowego z TopBar.tsx --- */
-.install-pwa-btn {
-    display: none !important;
-}
 
-@media (min-width: 768px) {
-    .install-pwa-btn {
-        display: block !important;
-        position: absolute;
-        top: 50%;
-        right: 40px;
-        transform: translateY(-50%);
-        width: auto;
-        padding: 0 10px;
-        font-weight: 600;
-        font-size: 14px;
-        color: white;
-    }
+/* PWA Prompt Styles from Reference */
+@keyframes slideInUp {
+    from { transform: translateY(100%); }
+    to { transform: translateY(0); }
 }
-/* --- Style dla promptu na mobilnym (PWAInstallPrompt.tsx) --- */
-.pwa-install-prompt-banner {
-    position: absolute;
+.hidden { display: none !important; }
+.pwa-prompt {
+    position: fixed;
     bottom: 0;
     left: 0;
     width: 100%;
-    background: rgba(45, 45, 45, 0.9);
-    -webkit-backdrop-filter: blur(10px);
-    backdrop-filter: blur(10px);
+    background: #333;
     color: white;
-    padding: 16px;
+    z-index: 10000;
     display: flex;
-    flex-direction: row;
-    justify-content: space-between;
     align-items: center;
-    text-align: left;
-    gap: 16px;
-    z-index: 110; /* Higher than bottombar's 105 */
-    height: var(--bottombar-height);
-    padding-bottom: calc(16px + var(--safe-area-bottom)); /* Adjust padding to account for safe area */
-    transform: translateY(100%);
-    transition: transform 0.3s ease-out, opacity 0.3s ease-out;
-    opacity: 0;
-    pointer-events: none;
+    justify-content: space-between;
+    padding: 1rem;
+    padding-bottom: calc(1rem + var(--safe-area-bottom));
+    box-shadow: 0 -2px 10px rgba(0,0,0,0.3);
+    animation: slideInUp 0.5s ease-out forwards;
 }
-
-.pwa-install-prompt-banner.visible {
-    transform: translateY(0);
-    opacity: 1;
-    pointer-events: auto;
+.pwa-prompt-title {
+    font-weight: bold;
+    font-size: 1.1rem;
+    margin: 0 0 0.25rem 0;
 }
-
-.pwa-install-prompt-banner h3 {
-    font-size: 18px;
-    font-weight: 700;
-}
-
-.pwa-install-prompt-banner p {
-    font-size: 14px;
-    margin-top: 4px;
+.pwa-prompt-description {
+    font-size: 0.9rem;
+    margin: 0;
     opacity: 0.8;
 }
-
-.pwa-install-prompt-banner .btn-primary {
-    background: #ef4444; /* Użyj koloru destrukcyjnego dla akcentu */
-    border: none;
-    padding: 12px 20px;
-    border-radius: 9999px; /* rounded-full */
-    font-size: 14px;
-    font-weight: 600;
-    white-space: nowrap;
-    transition: background-color 0.2s ease-in-out;
-}
-
-/* --- Style dla modalnych okien (PwaDesktopModal.tsx) --- */
-#pwaDesktopModal .modal-content,
-#pwaIosInstructions .modal-content {
-    background: rgba(30, 30, 30, 0.95);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
+.pwa-prompt-button {
+    background-color: var(--accent-color);
     color: white;
-    border-radius: 16px;
-    max-width: 400px;
+    border: none;
+    padding: 0.75rem 1.5rem;
+    border-radius: 8px;
+    font-weight: bold;
+    cursor: pointer;
+    flex-shrink: 0;
+    margin-left: 1rem;
+}
+.pwa-prompt-ios {
+    position: fixed;
+    bottom: 0;
+    left: 0;
     width: 100%;
-    padding: 32px;
-    text-align: center;
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: rgba(20, 20, 20, 0.9);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    color: white;
+    z-index: 10001;
+    padding: 1rem;
+    padding-bottom: calc(1rem + var(--safe-area-bottom));
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    animation: slideInUp 0.5s ease-out forwards;
 }
-#pwaDesktopModal h3,
-#pwaIosInstructions h3 {
-    font-size: 24px;
-    font-weight: 700;
-    margin-bottom: 16px;
+.pwa-ios-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+    font-weight: bold;
+    font-size: 1.2rem;
 }
-#pwaDesktopModal .qr-code-container {
-    width: 128px;
-    height: 128px;
-    background: white;
-    margin: 0 auto;
-    border-radius: 8px;
+.pwa-ios-close-button {
+    background: none;
+    border: none;
+    color: white;
+    font-size: 1.5rem;
+    cursor: pointer;
+    opacity: 0.7;
 }
-
-#pwaIosInstructions img {
-    max-width: 100px;
-    margin: 10px auto;
-    display: block;
-    background: #444;
-    padding: 10px;
-    border-radius: 8px;
+.pwa-ios-body {
+    font-size: 1rem;
+    line-height: 1.5;
 }
+.pwa-ios-body p { margin-bottom: 0.75rem; }


### PR DESCRIPTION
This commit implements the PWA installation prompt as a bottom bar, based on the user's provided reference implementation.

- Adds a new PWA installation bar (`#pwa-install-bar`) and an iOS-specific instruction overlay (`#pwa-ios-instructions`) to `index.html`.
- Adds the corresponding CSS to `style.css` to style and position these elements at the bottom of the viewport using `position: fixed`.
- Replaces the old PWA logic in `script.js` with a new, clean `PWA` module.
- The new logic correctly shows the install bar for browsers that support `beforeinstallprompt`.
- It also provides a fallback for iOS devices, showing the bar and making the button open the manual installation instructions.
- All old, unused HTML, CSS, and duplicated JavaScript for previous PWA prompt attempts have been removed.