### PR TITLE
feat: Implement unified PWA installation prompt

### DIFF
--- a/script.js
+++ b/script.js
@@ -1502,76 +1502,68 @@
          * PWA MODULE
          * ==========================================================================
          */
+const PWA = (function() {
+    let installPromptEvent = null;
+    const installBar = document.getElementById('pwa-install-bar');
+    const installButton = document.getElementById('pwa-install-button');
+    const iosInstructions = document.getElementById('pwa-ios-instructions');
+    const iosCloseButton = document.getElementById('pwa-ios-close-button');
+
+    function showInstallBar() {
+        if (!installBar || window.matchMedia('(display-mode: standalone)').matches) {
+            return;
+        }
+        installBar.classList.remove('hidden');
+    }
+
+    function init() {
+        if (window.matchMedia('(display-mode: standalone)').matches) {
+            return; // Already installed
+        }
+
+        const isIOS = /iPhone|iPad|iPod/i.test(navigator.userAgent) && !window.MSStream;
+
+        window.addEventListener('beforeinstallprompt', (e) => {
+            e.preventDefault();
+            installPromptEvent = e;
+            showInstallBar();
+        });
+
+        if (installButton) {
+            installButton.addEventListener('click', () => {
+                if (installPromptEvent) {
+                    installPromptEvent.prompt();
+                    installPromptEvent.userChoice.then(() => {
+                        installPromptEvent = null;
+                        if (installBar) {
+                            installBar.classList.add('hidden');
+                        }
+                    });
+                } else if (isIOS && iosInstructions) {
+                    iosInstructions.classList.remove('hidden');
+                    if (installBar) {
+                        installBar.classList.add('hidden');
+                    }
+                }
+            });
+        }
+
+        if (isIOS) {
+             showInstallBar();
+        }
+
+        if (iosCloseButton) {
+            iosCloseButton.addEventListener('click', () => {
+                if (iosInstructions) {
+                    iosInstructions.classList.add('hidden');
+                }
+            });
+        }
+    }
+
+    return { init };
+})();
 
 
         App.init();
-
-        /**
-         * ==========================================================================
-         * 10. PWA INSTALL PROMPT LOGIC
-         * ==========================================================================
-         */
-        const PWA = (function() {
-            let installPromptEvent = null;
-            const installBar = document.getElementById('pwa-install-bar');
-            const installButton = document.getElementById('pwa-install-button');
-            const iosInstructions = document.getElementById('pwa-ios-instructions');
-            const iosCloseButton = document.getElementById('pwa-ios-close-button');
-
-            function showInstallBar() {
-                if (!installBar || window.matchMedia('(display-mode: standalone)').matches) {
-                    return;
-                }
-                installBar.classList.remove('hidden');
-            }
-
-            function init() {
-                if (window.matchMedia('(display-mode: standalone)').matches) {
-                    return; // Already installed
-                }
-
-                const isIOS = /iPhone|iPad|iPod/i.test(navigator.userAgent) && !window.MSStream;
-
-                window.addEventListener('beforeinstallprompt', (e) => {
-                    e.preventDefault();
-                    installPromptEvent = e;
-                    showInstallBar();
-                });
-
-                if (installButton) {
-                    installButton.addEventListener('click', () => {
-                        if (installPromptEvent) {
-                            installPromptEvent.prompt();
-                            installPromptEvent.userChoice.then(() => {
-                                installPromptEvent = null;
-                                if (installBar) {
-                                    installBar.classList.add('hidden');
-                                }
-                            });
-                        } else if (isIOS && iosInstructions) {
-                            iosInstructions.classList.remove('hidden');
-                            if (installBar) {
-                                installBar.classList.add('hidden');
-                            }
-                        }
-                    });
-                }
-
-                if (isIOS) {
-                     showInstallBar();
-                }
-
-                if (iosCloseButton) {
-                    iosCloseButton.addEventListener('click', () => {
-                        if (iosInstructions) {
-                            iosInstructions.classList.add('hidden');
-                        }
-                    });
-                }
-            }
-
-            return { init };
-        })();
-
-        PWA.init();
     });


### PR DESCRIPTION
This commit replaces the various PWA installation prompts with a single, unified bottom bar, based on the user's reference implementation.

- Removes all old HTML, CSS, and JS related to previous PWA prompts.
- Adds a new PWA installation bar (`#pwa-install-bar`) and an iOS-specific instruction overlay (`#pwa-ios-instructions`) to `index.html`.
- Adds the corresponding CSS to `style.css` to style and position these elements correctly.
- Replaces the old PWA logic in `script.js` with a new, clean `PWA` module that is correctly integrated into the application's initialization flow.
- The new logic correctly shows the install bar for browsers that support `beforeinstallprompt`.
- It also provides a fallback for iOS devices, showing the bar and making the button open the manual installation instructions.

This resolves the issues of the prompt not appearing, the language selection panel disappearing, and duplicated code.