### PR TITLE
feat: Implement unified PWA installation prompt

### DIFF
--- a/script.js
+++ b/script.js
@@ -1513,7 +1513,26 @@ const PWA = (function() {
         if (!installBar || window.matchMedia('(display-mode: standalone)').matches) {
             return;
         }
-        installBar.classList.remove('hidden');
+
+                const preloader = document.getElementById('preloader');
+                // Check if preloader is visible and not already in the process of hiding
+                if (preloader && preloader.style.display !== 'none' && !preloader.classList.contains('preloader-hiding')) {
+                    const observer = new MutationObserver((mutationsList, observer) => {
+                        for(const mutation of mutationsList) {
+                            if (mutation.type === 'attributes' && mutation.attributeName === 'style') {
+                                if (preloader.style.display === 'none') {
+                                    installBar.classList.remove('hidden');
+                                    observer.disconnect();
+                                    return;
+                                }
+                            }
+                        }
+                    });
+                    observer.observe(preloader, { attributes: true });
+                } else if (!preloader || preloader.style.display === 'none') {
+                    // If preloader is already gone, show the bar
+                    installBar.classList.remove('hidden');
+                }
     }
 
     function init() {


### PR DESCRIPTION
This commit replaces the various PWA installation prompts with a single, unified bottom bar, based on the user's reference implementation.

- Removes all old HTML, CSS, and JS related to previous PWA prompts.
- Adds a new PWA installation bar (`#pwa-install-bar`) and an iOS-specific instruction overlay (`#pwa-ios-instructions`) to `index.html`.
- Adds the corresponding CSS to `style.css` to style and position these elements correctly.
- Replaces the old PWA logic in `script.js` with a new, clean `PWA` module that is correctly integrated into the application's initialization flow.
- The new logic correctly shows the install bar for browsers that support `beforeinstallprompt`.
- It also provides a fallback for iOS devices, showing the bar and making the button open the manual installation instructions.
- A `MutationObserver` is used to ensure the install bar only appears after the language selection preloader is hidden, fixing a key visibility bug.

This resolves all previously identified issues, including incorrect positioning, JavaScript errors, and the prompt being hidden by the preloader.