### PR TITLE
Fix PWA installation bar and its visibility

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,21 @@
 {
-  "name": "Simple PWA",
-  "short_name": "PWA",
+  "name": "Ting Tong",
+  "short_name": "Ting Tong",
   "start_url": ".",
   "display": "standalone",
-  "background_color": "#fff",
-  "description": "A simple PWA.",
-  "icons": [{
-    "src": "icon.png",
-    "sizes": "192x192",
-    "type": "image/png"
-  }]
+  "background_color": "#000000",
+  "theme_color": "#000000",
+  "description": "Ting Tong — pionowy feed wideo z prefetchingiem i trybem HLS/CDN-ready.",
+  "icons": [
+    {
+      "src": "https://pawelperfect.pl/wp-content/uploads/2025/07/output-onlinepngtools-1-1.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "https://pawelperfect.pl/wp-content/uploads/2025/07/output-onlinepngtools-1-1.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
 }


### PR DESCRIPTION
This commit fixes the PWA installation bar, which was not appearing on Android devices and had incorrect visibility behavior.

The following changes were made:
- `manifest.json`: Updated to point to a valid, existing icon URL and include a 512x512 icon size. This resolves the root cause of the `beforeinstallprompt` event not firing on Android.
- `style.css`: Increased the `z-index` of the PWA bar and iOS instructions to ensure they are always displayed on top of other content.
- `script.js`: Implemented the correct logic to show the bar on all devices (iOS, Android, Desktop) and ensure it does not disappear after the user clicks the install button, persisting until the app is installed.