### PR TITLE
fix: Use relative path for service worker registration

### DIFF
--- a/index.html
+++ b/index.html
@@ -379,7 +379,7 @@
     <script>
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', function() {
-          navigator.serviceWorker.register('/sw.js').then(function(registration) {
+          navigator.serviceWorker.register('sw.js').then(function(registration) {
             console.log('ServiceWorker registration successful with scope: ', registration.scope);
           }, function(err) {
             console.log('ServiceWorker registration failed: ', err);


### PR DESCRIPTION
The PWA installation prompt was not appearing on Android because the service worker failed to register. This was due to the registration script in index.html using an absolute path ('/sw.js').

If the application is hosted in a subdirectory, this path would be incorrect. Changed the path to a relative 'sw.js' to ensure it registers correctly regardless of the deployment location. This allows the 'beforeinstallprompt' event to fire, enabling the PWA installation banner.