### PR TITLE
Fix HLS video playback on non-native platforms

### DIFF
--- a/script.js
+++ b/script.js
@@ -605,7 +605,13 @@
                 const canAttach = slideData && !(slideData.access === 'secret' && !State.get('isUserLoggedIn'));
                 if (!canAttach) return;
 
-                const player = videojs(video);
+                const player = videojs(video, {
+                  html5: {
+                    hls: {
+                      ...Config.HLS
+                    }
+                  }
+                });
                 const sourceUrl = Config.USE_HLS && slideData.hlsUrl ? slideData.hlsUrl : slideData.mp4Url;
                 const sourceType = Config.USE_HLS && slideData.hlsUrl ? 'application/x-mpegURL' : 'video/mp4';
 


### PR DESCRIPTION
The video.js player was not being initialized with the necessary HLS configuration, causing video playback to fail on browsers without native HLS support (e.g., Chrome on desktop and Android).

This change passes the HLS configuration object to the video.js player during initialization. This enables the video.js HLS playback engine (VHS) and allows it to correctly play HLS streams on all supported platforms.