### PR TITLE
feat: Improve HLS playback with MP4 fallback

### DIFF
--- a/script.js
+++ b/script.js
@@ -608,15 +608,27 @@
                 const player = videojs(video, {
                   html5: {
                     hls: {
-                      ...Config.HLS
+                      ...Config.HLS,
+                      overrideNative: false // Let's be explicit as per best practices
+                    },
+                    vhs: {
+                      overrideNative: false
                     }
                   }
                 });
-                const sourceUrl = Config.USE_HLS && slideData.hlsUrl ? slideData.hlsUrl : slideData.mp4Url;
-                const sourceType = Config.USE_HLS && slideData.hlsUrl ? 'application/x-mpegURL' : 'video/mp4';
 
-                if (sourceUrl) {
-                    player.src({ src: sourceUrl, type: sourceType });
+                const sources = [];
+                const useHls = Config.USE_HLS && slideData.hlsUrl;
+
+                if (useHls) {
+                    sources.push({ src: slideData.hlsUrl, type: 'application/x-mpegURL' });
+                }
+                if (slideData.mp4Url) {
+                    sources.push({ src: slideData.mp4Url, type: 'video/mp4' });
+                }
+
+                if (sources.length > 0) {
+                    player.src(sources);
                     attachedSet.add(video);
                 }
             }


### PR DESCRIPTION
Implements the primary recommendation from the technical analysis to improve video playback reliability across browsers.

- Modifies the Video.js initialization to provide an array of sources (HLS and MP4) instead of a single source. This allows the player to automatically fall back to MP4 if the HLS stream fails, which is common in browsers without native HLS support due to CORS restrictions.
- Explicitly sets `overrideNative: false` in the player's HLS/VHS configuration to ensure native browser support (e.g., on Safari) is prioritized, aligning with best practices for performance and compatibility.