### PR TITLE
feat: Fix PWA installation and wide-screen layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <!-- PATCH: iOS PWA cosmetics -->
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-    <link rel="apple-touch-icon" href="https://pawelperfect.pl/wp-content/uploads/2025/07/output-onlinepngtools-1-1.png">
+    <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
     <!-- PATCH: TODO - Add iOS splash screens for different devices -->
     <!--
     <link href="splash/iphone5_splash.png" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
@@ -60,7 +60,7 @@
 <body>
     <div id="preloader">
         <div class="preloader-icon-container">
-            <img src="https://pawelperfect.pl/wp-content/uploads/2025/07/output-onlinepngtools-1-1.png" alt="Ting Tong Logo" class="splash-icon">
+            <img src="assets/icons/icon-192.png" alt="Ting Tong Logo" class="splash-icon">
         </div>
         <div class="preloader-content-container">
             <div class="language-selection">

--- a/manifest.json
+++ b/manifest.json
@@ -8,12 +8,12 @@
   "description": "Ting Tong — pionowy feed wideo z prefetchingiem i trybem HLS/CDN-ready.",
   "icons": [
     {
-      "src": "https://pawelperfect.pl/wp-content/uploads/2025/07/output-onlinepngtools-1-1.png",
+      "src": "assets/icons/icon-192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "https://pawelperfect.pl/wp-content/uploads/2025/07/output-onlinepngtools-1-1.png",
+      "src": "assets/icons/icon-512.png",
       "sizes": "512x512",
       "type": "image/png"
     }

--- a/style.css
+++ b/style.css
@@ -1748,9 +1748,10 @@
     #app-frame {
         position: relative;
         height: 100vh;
+        /* Use a 9:16 aspect ratio, but don't let it get too wide */
         width: calc(100vh * 9 / 16);
+        max-width: 450px;
         max-height: 100%;
-        max-width: 100%;
         margin: 0 auto;
         border-left: 1px solid #333;
         border-right: 1px solid #333;


### PR DESCRIPTION
This commit addresses two main issues:
1. PWA installation prompt now works correctly on Android/desktop.
2. The application layout is constrained to a centered, phone-like container on wide screens.

PWA & Installation:
- Modified `manifest.json` and `index.html` to use relative paths for icons, making the PWA installable from any domain (including localhost).
- Created `assets/icons` directory for PWA icons.
- Refactored the PWA module in `script.js` to provide a more robust installation experience.
- On iOS, specific "Add to Home Screen" instructions are now shown directly.
- On Android/desktop, a custom install bar is always shown. The button triggers the native prompt if available, and falls back to a Google Play link otherwise.

Layout:
- Added `max-width: 450px` to the `#app-frame` in `style.css` for screens wider than 600px. This prevents the container from stretching excessively while maintaining its mobile aspect ratio.