### PR TITLE
feat: Enable and position Video.js controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
         <template id="slide-template">
             <div class="webyx-section swiper-slide">
                 <div class="tiktok-symulacja">
-                    <video class="videoPlayer video-js" controls muted loop playsinline webkit-playsinline autoplay preload="metadata" poster="placeholder.jpg" oncontextmenu="return false;" crossorigin="anonymous">
+                    <video class="videoPlayer video-js" muted loop playsinline webkit-playsinline autoplay preload="metadata" poster="placeholder.jpg" oncontextmenu="return false;" crossorigin="anonymous">
                         <source src="" type="video/mp4" />
                         Twoja przeglądarka nie obsługuje wideo.
                     </video>

--- a/style.css
+++ b/style.css
@@ -1845,3 +1845,9 @@
     line-height: 1.5;
 }
 .pwa-ios-body p { margin-bottom: 0.75rem; }
+
+/* Custom Video.js styles to position control bar above the bottom bar */
+.tiktok-symulacja .vjs-control-bar {
+    bottom: var(--bottombar-height, 110px);
+    background-color: rgba(0, 0, 0, 0.5) !important;
+}


### PR DESCRIPTION
This commit correctly enables the Video.js player's built-in controls and positions them according to the user's request.

- Removes the `controls` attribute from the `<video>` tag in `index.html`. This prevents the browser's native controls from appearing and allows the Video.js library to render its own skinned controls.
- Adds custom CSS to `style.css` to position the Video.js control bar (`.vjs-control-bar`) above the app's custom bottom navigation bar. This ensures the controls are visible and correctly placed within the UI.

This resolves the user's request for a functional, "original" Video.js progress bar and tap-to-play/pause functionality.