### PR TITLE
feat: Enable video controls to show progress bar

### DIFF
--- a/script.js
+++ b/script.js
@@ -606,6 +606,7 @@
                 if (!canAttach) return;
 
                 const player = videojs(video, {
+                  controls: true, // Włącz domyślne kontrolki
                   html5: {
                     hls: {
                       ...Config.HLS,


### PR DESCRIPTION
Adds `controls: true` to the Video.js initialization options. This enables the default video player controls, including the seekable progress bar, volume controls, and play/pause button, which were previously not visible.