### PR TITLE
feat: Add individual video progress bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,6 +124,9 @@
                         </button>
                     </div>
                     <div class="bottombar">
+                        <div class="video-progress-container">
+                            <div class="video-progress-bar"></div>
+                        </div>
                         <div class="text-info">
                             <div class="text-user"></div>
                             <div class="text-description"></div>

--- a/script.js
+++ b/script.js
@@ -637,6 +637,21 @@
                 if (sources.length > 0) {
                     player.src(sources);
                     attachedSet.add(video);
+
+                    const progressBar = sectionEl.querySelector('.video-progress-bar');
+                    if (progressBar) {
+                        player.on('timeupdate', function() {
+                            const duration = player.duration();
+                            if (isFinite(duration) && duration > 0) {
+                                const progress = (player.currentTime() / duration) * 100;
+                                progressBar.style.width = progress + '%';
+                            }
+                        });
+
+                        player.on('ended', function() {
+                            progressBar.style.width = '0%';
+                        });
+                    }
                 }
             }
 
@@ -664,6 +679,10 @@
                     const oldVideo = oldSlide.querySelector('.videoPlayer');
                     if (oldVideo) {
                         videojs(oldVideo).pause();
+                    }
+                    const oldProgressBar = oldSlide.querySelector('.video-progress-bar');
+                    if (oldProgressBar) {
+                        oldProgressBar.style.width = '0%';
                     }
                 }
 

--- a/style.css
+++ b/style.css
@@ -376,6 +376,23 @@
             text-shadow: 0 0 4px rgba(0, 0, 0, 0.8);
         }
 
+        .video-progress-container {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 2px;
+            background-color: rgba(255, 255, 255, 0.25);
+            z-index: 106;
+        }
+
+        .video-progress-bar {
+            width: 0%;
+            height: 100%;
+            background-color: var(--accent-color);
+            transition: width 0.1s linear;
+        }
+
         /* ==========================================================================
            --- KOMPONENTY UI: PRZYCISKI I IKONY ---
            ========================================================================== */


### PR DESCRIPTION
This commit introduces a native, individual progress bar for each video slide.

- Adds a new progress bar element to the slide template in `index.html`.
- Styles the progress bar in `style.css` to be displayed at the top of the bottom bar with an appropriate z-index.
- Updates `script.js` to add `timeupdate` and `ended` event listeners to each video player.
- The progress bar now visually represents the current playback time of the video and resets when the video ends or the slide is changed.