### PR TITLE
Fix: Correct video stuttering and progress bar behavior

### DIFF
--- a/script.js
+++ b/script.js
@@ -216,7 +216,7 @@
           USE_HLS: true,
           PREFETCH_NEIGHBORS: true,
           PREFETCH_MARGIN: '150%',
-          UNLOAD_FAR_SLIDES: true,
+          UNLOAD_FAR_SLIDES: false,
           FAR_DISTANCE: 2,
           LOW_DATA_MODE: false,
           RETRY_MAX_ATTEMPTS: 2,
@@ -679,10 +679,6 @@
                     const oldVideo = oldSlide.querySelector('.videoPlayer');
                     if (oldVideo) {
                         videojs(oldVideo).pause();
-                    }
-                    const oldProgressBar = oldSlide.querySelector('.video-progress-bar');
-                    if (oldProgressBar) {
-                        oldProgressBar.style.width = '0%';
                     }
                 }
 


### PR DESCRIPTION
This commit addresses two issues related to video playback:

1.  Videos would stutter or lag when scrolling back to them. This was caused by an aggressive optimization that unloaded videos from memory when they were no longer visible. This has been disabled by setting `UNLOAD_FAR_SLIDES` to `false`, prioritizing a smoother user experience over lower memory usage.

2.  The custom video progress bar would reset to 0% whenever a slide became inactive. This caused a visual glitch and meant that the user's progress in a video was not visually preserved. The code that reset the progress bar has been removed.