### PR TITLE
feat: Implement video player UX improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,11 @@
                         <source src="" type="video/mp4" />
                         Twoja przeglądarka nie obsługuje wideo.
                     </video>
+                    <div class="pause-overlay" aria-hidden="true">
+                        <svg class="pause-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M5.25 21a.75.75 0 01-.75-.75V3.75a.75.75 0 011.5 0v16.5a.75.75 0 01-.75.75zM18.75 21a.75.75 0 01-.75-.75V3.75a.75.75 0 011.5 0v16.5a.75.75 0 01-.75.75z" />
+                        </svg>
+                    </div>
                     <div class="secret-overlay" aria-hidden="true">
                         <svg class="secret-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 00-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" /></svg>
                         <h2 class="secret-title" data-translate-key="secretTitle">Top Secret</h2>

--- a/script.js
+++ b/script.js
@@ -1449,6 +1449,29 @@
                 document.body.addEventListener('click', Handlers.mainClickHandler);
                 UI.DOM.container.addEventListener('submit', Handlers.formSubmitHandler);
 
+                UI.DOM.container.addEventListener('click', (e) => {
+                    const slide = e.target.closest('.swiper-slide');
+                    if (!slide) return;
+
+                    if (e.target.closest('.sidebar, .bottombar, .vjs-control-bar')) {
+                        return;
+                    }
+
+                    const video = slide.querySelector('.videoPlayer');
+                    const pauseOverlay = slide.querySelector('.pause-overlay');
+
+                    if (video) {
+                        const player = videojs(video);
+                        if (player.paused()) {
+                            player.play();
+                            if (pauseOverlay) pauseOverlay.classList.remove('visible');
+                        } else {
+                            player.pause();
+                            if (pauseOverlay) pauseOverlay.classList.add('visible');
+                        }
+                    }
+                });
+
                 document.querySelectorAll('.modal-overlay:not(#accountModal)').forEach(modal => {
                     modal.addEventListener('click', (e) => { if (e.target === modal) UI.closeModal(modal); });
                     modal.querySelector('.modal-close-btn, .topbar-close-btn')?.addEventListener('click', () => UI.closeModal(modal));
@@ -1618,9 +1641,14 @@ const PWA = (function() {
         else if (isIOS()) {
             showIosInstructions();
         }
-        // Fallback for other systems (e.g., Android with failed PWA criteria): link to the store.
+        // Fallback for other systems (e.g., Android with failed PWA criteria): trigger a file download.
         else {
-            window.open('https://play.google.com/store/apps/details?id=com.tingtong.app', '_blank');
+            const a = document.createElement('a');
+            a.href = 'tingtong.pwa';
+            a.download = 'tingtong.pwa';
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
         }
     }
 

--- a/style.css
+++ b/style.css
@@ -281,6 +281,30 @@
         .videoPlayer.secret-active {
             filter: blur(12px) saturate(120%);
         }
+        .pause-overlay {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background-color: rgba(0, 0, 0, 0.3);
+            z-index: 101;
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease-in-out;
+        }
+        .pause-overlay.visible {
+            opacity: 1;
+        }
+        .pause-icon {
+            width: 80px;
+            height: 80px;
+            color: rgba(255, 255, 255, 0.8);
+            filter: drop-shadow(0 0 10px rgba(0, 0, 0, 0.5));
+        }
         .topbar,
         .tiktok-symulacja .bottombar,
         .login-panel {
@@ -383,7 +407,7 @@
             width: 100%;
             height: 8px; /* Increased thickness */
             background-color: rgba(255, 255, 255, 0.25);
-            z-index: 106;
+            z-index: 10003;
         }
 
         .video-progress-bar {

--- a/tingtong.pwa
+++ b/tingtong.pwa
@@ -1,0 +1,3 @@
+This is a placeholder file for the PWA download.
+Installing a PWA is typically done through the browser's "Add to Home Screen" or "Install" feature, not by downloading a file.
+If you are seeing this file, it means the browser you are using does not support the standard PWA installation process.


### PR DESCRIPTION
This commit introduces several user experience improvements to the video player and PWA functionality based on user feedback.

- **Tap to Pause/Play:** Users can now tap on the video to toggle between playing and paused states. A pause icon is displayed when the video is paused to provide clear visual feedback.

- **Progress Bar Z-Index:** The video progress bar's z-index has been increased to ensure it is always displayed on top of other UI elements, such as the PWA installation bar.

- **PWA Installation Fallback:** The PWA installation button's fallback behavior for Android and desktop has been modified. When the native PWA installation prompt is not available, it now triggers a download of a placeholder `tingtong.pwa` file, as per the user's specific request.