### PR TITLE
feat: Relocate progress bar to bottom and fix PWA button

### DIFF
--- a/script.js
+++ b/script.js
@@ -1702,6 +1702,32 @@ const PWA = (function() {
         }
     }
 
+    // --- PATCH: Dynamically adjust progress bar for PWA prompt ---
+    const pwaBar = document.getElementById('pwa-install-bar');
+    const root = document.documentElement;
+
+    if (pwaBar) {
+        const pwaObserver = new MutationObserver(() => {
+            requestAnimationFrame(() => {
+                if (pwaBar.classList.contains('visible')) {
+                    // When PWA bar is visible, position the progress bar above it.
+                    root.style.setProperty('--progress-bar-bottom-offset', `${pwaBar.offsetHeight}px`);
+                } else {
+                    // When PWA bar is hidden, revert to the default position above the main bottom bar.
+                    root.style.removeProperty('--progress-bar-bottom-offset');
+                }
+            });
+        });
+
+        pwaObserver.observe(pwaBar, { attributes: true, attributeFilter: ['class'] });
+
+        // Initial check in case the bar is already visible on load
+        if (pwaBar.classList.contains('visible')) {
+             root.style.setProperty('--progress-bar-bottom-offset', `${pwaBar.offsetHeight}px`);
+        }
+    }
+    // --- END PATCH ---
+
     return { init };
 })();
 

--- a/style.css
+++ b/style.css
@@ -1841,6 +1841,9 @@
     cursor: pointer;
     flex-shrink: 0;
     margin-left: 1rem;
+    position: relative; /* Create a new stacking context */
+    z-index: 1; /* Ensure it's above other content in the same flex container */
+    pointer-events: auto !important; /* Force clickability */
 }
 .pwa-prompt-ios {
     position: fixed;
@@ -1887,28 +1890,25 @@
 }
 .pwa-ios-body p { margin-bottom: 0.75rem; }
 
-/* --- PATCH: Relocated Video.js progress bar --- */
+/* --- PATCH: Relocated Video.js progress bar to the bottom --- */
 
-/* Move the entire control bar to the top and make it act as the progress bar container */
+/* Position the control bar at the bottom, using a variable for dynamic shifting. */
 .tiktok-symulacja .vjs-control-bar {
-    position: absolute !important;
-    top: var(--topbar-height) !important;
-    left: 0 !important;
-    width: 100% !important;
-    height: 3px !important; /* Set height for the progress bar */
+    position: absolute;
+    bottom: var(--progress-bar-bottom-offset, var(--bottombar-height, 110px));
+    left: 0;
+    width: 100%;
+    height: 3px;
     background-color: transparent !important;
-    z-index: 116 !important;
-
-    /* Force visibility of the bar itself */
-    display: flex !important; /* Video.js uses flex */
+    z-index: 116;
+    display: flex !important;
     visibility: visible !important;
     opacity: 1 !important;
-    transition: height 0.2s ease-out !important;
-    bottom: auto !important; /* Override default bottom positioning */
+    transition: all 0.3s ease-out !important;
 }
 
 .tiktok-symulacja .vjs-control-bar:hover {
-    height: 6px !important; /* Make it easier to grab */
+    height: 6px;
 }
 
 /* Hide all controls inside the bar by default */
@@ -1918,7 +1918,7 @@
 
 /* BUT, explicitly show the progress control and make it fill the parent */
 .tiktok-symulacja .vjs-progress-control {
-    display: flex !important; /* It's a flex item, so display it */
+    display: flex !important;
     position: absolute;
     top: 0;
     left: 0;
@@ -1926,25 +1926,17 @@
     height: 100%;
 }
 
-.tiktok-symulacja .vjs-progress-control:hover {
-    height: 6px;
-}
-
-/* Keep the visual style of the progress bar */
+/* Style the progress bar itself */
 .tiktok-symulacja .vjs-play-progress {
     background: linear-gradient(90deg, #00AEEF, #0089D1);
     box-shadow: 0 0 8px rgba(0, 174, 239, 0.5);
-    border-radius: 0; /* Full width */
-}
-
-.tiktok-symulacja .vjs-load-progress {
-    background: rgba(255, 255, 255, 0.5);
+    border-radius: 0;
 }
 
 .tiktok-symulacja .vjs-progress-holder {
     height: 100%;
-    background-color: rgba(255, 255, 255, 0.25); /* Original background */
-    border-radius: 0; /* Full width */
+    background-color: rgba(255, 255, 255, 0.25);
+    border-radius: 0;
     margin: 0;
 }
 
@@ -1967,8 +1959,7 @@
     opacity: 1;
 }
 
-
-/* --- Video Error Overlay (Unchanged) --- */
+/* --- Video Error Overlay --- */
 .error-overlay {
     position: absolute;
     top: 0;
@@ -2039,7 +2030,7 @@
     transform: scale(0.95);
 }
 
-/* Unify UI by hiding redundant/unused Video.js controls (Unchanged) */
+/* Unify UI by hiding redundant/unused Video.js controls */
 .tiktok-symulacja .vjs-volume-panel,
 .tiktok-symulacja .vjs-picture-in-picture-control,
 .tiktok-symulacja .vjs-fullscreen-control,


### PR DESCRIPTION
This commit implements the user's request to move the video progress bar to the bottom of the screen and fix an issue with the PWA installation button.

The video progress bar is now positioned to sit just above the main bottom bar. A MutationObserver has been added to the JavaScript to watch for the appearance of the PWA installation prompt. When the prompt is visible, the progress bar dynamically repositions itself to sit above the prompt, ensuring it is always visible.

Additionally, a CSS fix has been applied to the PWA installation button to ensure it has the correct stacking context and pointer-events, making it clickable as intended.