### PR TITLE
feat: Add responsive styles for wide screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -1772,9 +1772,7 @@
     #app-frame {
         position: relative;
         height: 100vh;
-        /* Use a 9:16 aspect ratio, but don't let it get too wide */
-        width: calc(100vh * 9 / 16);
-        max-width: 450px;
+        max-width: 600px; /* Tablet view: a bit wider, up to 600px  */
         max-height: 100%;
         margin: 0 auto;
         border-left: 1px solid #333;
@@ -1785,6 +1783,15 @@
     #webyx-container {
         width: 100%;
         height: 100%;
+    }
+}
+
+@media (min-width: 1000px) {
+    #app-frame {
+        max-width: 400px; /* Desktop view: narrower, up to 400px  */
+        max-height: 100%;
+        border-left: 1px solid #333;
+        border-right: 1px solid #333;
     }
 }
 


### PR DESCRIPTION
Implements a responsive design for wide screens (tablets and desktops) by limiting the application's width and centering it.

- On screens between 600px and 1000px, the max-width is set to 600px.
- On screens wider than 1000px, the max-width is narrowed to 400px to better simulate a phone experience.

This prevents the application from stretching across the entire viewport on wider displays.