### PR TITLE
fix(pwa): Make install button trigger system prompt reliably

### DIFF
--- a/script.js
+++ b/script.js
@@ -1662,7 +1662,7 @@ const PWA = (function() {
             installPromptEvent.prompt();
             installPromptEvent.userChoice.then(() => {
                 installPromptEvent = null;
-                installBar.classList.add('hidden');
+                installBar.classList.remove('visible');
             });
         } else if (isIOS()) {
             showIosInstructions();
@@ -1675,10 +1675,17 @@ const PWA = (function() {
             return; // Don't set up any prompts if the app is already installed.
         }
 
+        if (installButton) {
+            installButton.disabled = true;
+        }
+
         // Listen for the native install prompt event
         window.addEventListener('beforeinstallprompt', (e) => {
             e.preventDefault();
             installPromptEvent = e;
+            if (installButton) {
+                installButton.disabled = false;
+            }
             // Show the bar because we know it's installable
             showInstallBar();
         });


### PR DESCRIPTION
The PWA install button was not reliably triggering the system installation prompt. This was due to a race condition where the install bar and button were displayed proactively before the `beforeinstallprompt` event had fired, leaving the button non-functional until the event was captured.

This commit fixes the issue by:
1.  Disabling the install button by default on page load.
2.  Enabling the install button only after the `beforeinstallprompt` event has been successfully captured.
3.  Correcting the logic to hide the install bar after the prompt is used by removing the `.visible` class, which aligns with the existing CSS.

This ensures that the install button is only clickable when the app is actually installable, providing a better user experience and reliably triggering the system prompt on compatible devices.