### PR TITLE
Fix top bar visibility on wide screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -1781,6 +1781,7 @@
         box-shadow: 0 0 20px rgba(0,0,0,0.5);
     }
     #webyx-container {
+        position: absolute;
         width: 100%;
         height: 100%;
     }


### PR DESCRIPTION
This change addresses an issue where the top bar was hidden on wide screen displays.

The root cause was the main content container (`#webyx-container`) having `position: fixed`, which caused it to overlay the entire viewport, obscuring other elements.

The fix is to change the container's position to `absolute` within the existing media query for wide screens. This correctly constrains the content container within its centered parent frame, making the top bar visible and ensuring the desired phone-like layout is displayed correctly.