### PR TITLE
feat: Improve PWA install flow and update video controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
                     </video>
                     <div class="pause-overlay" aria-hidden="true">
                         <svg class="pause-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
-                            <path d="M5.25 21a.75.75 0 01-.75-.75V3.75a.75.75 0 011.5 0v16.5a.75.75 0 01-.75.75zM18.75 21a.75.75 0 01-.75-.75V3.75a.75.75 0 011.5 0v16.5a.75.75 0 01-.75.75z" />
+                            <path d="M8 5v14l11-7z" />
                         </svg>
                     </div>
                     <div class="secret-overlay" aria-hidden="true">

--- a/script.js
+++ b/script.js
@@ -854,7 +854,7 @@
                         installPromptEvent = null;
                         installBar.classList.remove('visible');
                     });
-                } else if (isIOS()) {
+                } else {
                     showIosInstructions();
                 }
             }
@@ -865,9 +865,6 @@
                     return; // Don't set up any prompts if the app is already installed.
                 }
 
-                if (installButton) {
-                    installButton.disabled = true;
-                }
 
                 // Listen for the native install prompt event
                 window.addEventListener('beforeinstallprompt', (e) => {


### PR DESCRIPTION
This commit addresses several user requests to improve the PWA experience:

1.  **Update Pause Icon:** The pause icon in the video overlay has been changed from a pause symbol (||) to a play symbol (a triangle). This provides clearer visual feedback when the video is paused.

2.  **Make Install Button Always Active:** The PWA install button is now always enabled if the app is not already in standalone mode. If the browser's native `beforeinstallprompt` event has fired, the button will trigger the system's installation prompt. If the event is not available, it will fall back to showing manual installation instructions. This change is made to meet the user's requirement of having a consistently interactive install button.

All changes have been verified and reviewed.