### PR TITLE
feat: Unify preloader and application splash images

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <!-- PATCH: iOS PWA cosmetics -->
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-    <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
+    <link rel="apple-touch-icon" href="https://picsum.photos/192">
     <!-- PATCH: TODO - Add iOS splash screens for different devices -->
     <!--
     <link href="splash/iphone5_splash.png" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
@@ -60,7 +60,7 @@
 <body>
     <div id="preloader">
         <div class="preloader-icon-container">
-            <img src="assets/icons/icon-192.png" alt="Ting Tong Logo" class="splash-icon">
+            <img src="https://picsum.photos/192" alt="Ting Tong Logo" class="splash-icon">
         </div>
         <div class="preloader-content-container">
             <div class="language-selection">


### PR DESCRIPTION
Updates the preloader splash image and the Apple touch icon to use the same URL as the application splash icon defined in manifest.json.

This ensures a consistent look and feel when launching the application and during initial load, as requested by the user.