### PR TITLE
fix(player): Correct Video.js progress bar functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <!-- PATCH: iOS PWA cosmetics -->
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-    <link rel="apple-touch-icon" href="https://picsum.photos/192">
+    <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
     <!-- PATCH: TODO - Add iOS splash screens for different devices -->
     <!--
     <link href="splash/iphone5_splash.png" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
@@ -60,7 +60,7 @@
 <body>
     <div id="preloader">
         <div class="preloader-icon-container">
-            <img src="https://picsum.photos/192" alt="Ting Tong Logo" class="splash-icon">
+            <img src="assets/icons/icon-192.png" alt="Ting Tong Logo" class="splash-icon">
         </div>
         <div class="preloader-content-container">
             <div class="language-selection">

--- a/style.css
+++ b/style.css
@@ -1884,20 +1884,6 @@
     height: 6px;
 }
 
-/* Hide all controls inside the bar by default */
-.tiktok-symulacja .vjs-control-bar > .vjs-control {
-    display: none;
-}
-
-/* BUT, explicitly show the progress control and make it fill the parent */
-.tiktok-symulacja .vjs-progress-control {
-    display: flex !important;
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-}
 
 /* Style the progress bar itself */
 .tiktok-symulacja .vjs-play-progress {
@@ -2004,11 +1990,13 @@
 }
 
 /* Unify UI by hiding redundant/unused Video.js controls */
+.tiktok-symulacja .vjs-play-control,
 .tiktok-symulacja .vjs-volume-panel,
 .tiktok-symulacja .vjs-picture-in-picture-control,
 .tiktok-symulacja .vjs-fullscreen-control,
 .tiktok-symulacja .vjs-duration,
 .tiktok-symulacja .vjs-current-time,
-.tiktok-symulacja .vjs-time-divider {
+.tiktok-symulacja .vjs-time-divider,
+.tiktok-symulacja .vjs-remaining-time-display {
     display: none !important;
 }


### PR DESCRIPTION
Removes the CSS rule that was hiding all Video.js controls, which broke the progress bar's functionality. Replaced it with a more specific set of rules that hides only the unwanted control elements, allowing the progress bar to function correctly while maintaining the desired UI.