### PR TITLE
Fix: Elevate desktop PWA modal z-index

### DIFF
--- a/style.css
+++ b/style.css
@@ -1864,6 +1864,9 @@
 .pwa-ios-body p { margin-bottom: 0.75rem; }
 
 /* --- Desktop PWA Modal --- */
+#pwa-desktop-modal {
+    z-index: 10004;
+}
 #pwa-desktop-modal .modal-content {
     background: white;
     color: #111;


### PR DESCRIPTION
The modal that informs desktop users to switch to a mobile device was being obscured by the PWA installation prompt.

This change increases the z-index of the desktop-specific modal (`#pwa-desktop-modal`) to `10004`, ensuring it appears on top of the installation prompt (`.pwa-prompt` at z-index `10002`) and the iOS-specific prompt (`.pwa-prompt-ios` at z-index `10003`).