### PR TITLE
feat: Make video progress bar full-width

### DIFF
--- a/style.css
+++ b/style.css
@@ -1916,6 +1916,10 @@
     height: 6px;
 }
 
+/* Make the progress bar fill the width of the control bar */
+.tiktok-symulacja .vjs-progress-control {
+    flex-grow: 1;
+}
 
 /* Style the progress bar itself */
 .tiktok-symulacja .vjs-play-progress {


### PR DESCRIPTION
The video progress bar was not spanning the full width of the video player. This was because the `.vjs-progress-control` element was not set to grow within its flex container.

This change adds a CSS rule to set `flex-grow: 1` on the `.vjs-progress-control` element, making it expand to fill the available space.