### PR TITLE
Fix: Ensure video progress bar is full width

### DIFF
--- a/style.css
+++ b/style.css
@@ -224,7 +224,7 @@
             left: 0;
             width: 100%;
             height: 100%;
-            object-fit: cover;
+            object-fit: fill;
             z-index: 10;
             background:transparent;
             opacity:1;


### PR DESCRIPTION
The `object-fit: cover` property on the video player was causing the video to maintain its aspect ratio, which resulted in black bars (letterboxing) when the container's aspect ratio was different. The video progress bar was then sized relative to the visible video frame, not the full width of the container.

By changing the `object-fit` property to `fill`, the video is stretched to fill the entire container. This ensures that the progress bar, which is aligned with the video, now spans the full width of the screen as intended. This may cause the video's aspect ratio to be distorted, but it resolves the primary issue of the progress bar's width.