### PR TITLE
Fix: Ensure video progress bar is full-width

### DIFF
--- a/style.css
+++ b/style.css
@@ -376,7 +376,7 @@
             display: flex;
             flex-direction: column;
             justify-content: flex-start;
-            padding: 10px 10px 10px 12px;
+    padding: 10px 75px 10px 12px;
             color: white;
             z-index: 105;
             padding-bottom: calc(10px + var(--safe-area-bottom));
@@ -1902,7 +1902,8 @@
     position: absolute;
     bottom: var(--progress-bar-bottom-offset, var(--bottombar-height, 110px));
     left: 0;
-    width: 100%;
+    right: 0;
+    width: auto;
     height: 3px;
     background-color: transparent !important;
     z-index: 116;


### PR DESCRIPTION
The video progress bar was not spanning the full width of the viewport, leaving a small margin on the left and a larger one on the right.

This was caused by a subtle layout issue where the progress bar's width was being incorrectly calculated.

This commit fixes the issue by changing the CSS for the `.vjs-control-bar` element. Instead of `width: 100%`, it now uses `left: 0; right: 0; width: auto;` to ensure it robustly stretches to the full width of its container.

Additionally, this commit fixes a related layout bug where the text in the bottom bar would overlap with the sidebar icons by increasing the right padding on the `.bottombar` element.