### PR TITLE
feat: Make one slide secret

### DIFF
--- a/script.js
+++ b/script.js
@@ -184,7 +184,7 @@
                         'hlsUrl': 'https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8',
                         'poster': '',
                         'avatar': 'https://i.pravatar.cc/100?u=apple',
-                        'access': 'public',
+                        'access': 'secret',
                         'initialLikes': 2200,
                         'isLiked': false,
                         'initialComments': 1245


### PR DESCRIPTION
This commit changes the access property of the second slide to 'secret'. This will make the slide only accessible to logged-in users.