### PR TITLE
feat: Make progress bar visible on secret slides

### DIFF
--- a/style.css
+++ b/style.css
@@ -1911,10 +1911,23 @@
     visibility: visible !important;
     opacity: 1 !important;
     transition: all 0.3s ease-out !important;
+    /* NOWA ZMIANA: Zapewnia, że pasek postępu jest zawsze widoczny na warstwie wyżej. */
+    pointer-events: auto !important;
 }
 
 .tiktok-symulacja .vjs-control-bar:hover {
     height: 6px;
+}
+
+/* Upewnij się, że inne części paska postępu również są widoczne i interaktywne. */
+.tiktok-symulacja .vjs-progress-control,
+.tiktok-symulacja .vjs-progress-holder,
+.tiktok-symulacja .vjs-play-progress {
+    display: block !important;
+    visibility: visible !important;
+    opacity: 1 !important;
+    pointer-events: auto !important;
+    z-index: 117; /* Ustaw wyższy z-index, aby być nad nakładką secret-overlay */
 }
 
 /* Make the progress bar fill the width of the control bar */


### PR DESCRIPTION
This change modifies the CSS to ensure the video progress bar is always visible, even on slides with the 'secret' overlay.

The following changes were made to `style.css`:
- Added `pointer-events: auto !important` to `.tiktok-symulacja .vjs-control-bar` to make it interactive.
- Created a new rule for `.tiktok-symulacja .vjs-progress-control`, `.tiktok-symulacja .vjs-progress-holder`, and `.tiktok-symulacja .vjs-play-progress` to ensure they are always displayed.
- Set a `z-index` of 117 on these elements to ensure they appear above the secret overlay (which has a z-index of 100).