### PR TITLE
fix: Ensure progress bar is visible on secret slides for all users

### DIFF
--- a/script.js
+++ b/script.js
@@ -599,9 +599,6 @@
                 const video = sectionEl.querySelector('.videoPlayer');
                 if (!video) return;
 
-                // --- PATCH START ---
-                // Initialize player even if already attached, to handle potential disposal.
-                // Video.js handles this gracefully.
                 const player = videojs(video, {
                   controls: true,
                   html5: {
@@ -645,27 +642,25 @@
                 if (canAttachSrc) {
                     const sources = [];
                     const useHls = Config.USE_HLS && slideData.hlsUrl;
-
                     if (useHls) {
                         sources.push({ src: slideData.hlsUrl, type: 'application/x-mpegURL' });
                         if (slideData.mp4Url) sources.push({ src: slideData.mp4Url, type: 'video/mp4' });
                     } else if (slideData.mp4Url) {
                         sources.push({ src: slideData.mp4Url, type: 'video/mp4' });
                     }
-
-                    // Only set src if it's different to avoid re-loading
                     const currentSrc = player.currentSrc();
                     const newSrc = sources[0]?.src;
                     if (newSrc && currentSrc !== newSrc) {
                         player.src(sources);
                     }
                 } else {
-                    // If user can't access, ensure no source is loaded
                     if (player.currentSrc()) {
                         player.reset();
                     }
+                    // --- NEW FIX ---
+                    // Trick Video.js into thinking playback has started to show controls.
+                    player.addClass('vjs-has-started');
                 }
-                // --- PATCH END ---
             }
 
             function _detachSrc(sectionEl) {

--- a/style.css
+++ b/style.css
@@ -1919,24 +1919,30 @@
     height: 6px;
 }
 
-/* Upewnij się, że inne części paska postępu również są widoczne i interaktywne. */
-.tiktok-symulacja .vjs-progress-control,
-.tiktok-symulacja .vjs-progress-holder,
+/* Ensure all parts of the progress bar are visible, interactive, and styled correctly. */
+.tiktok-symulacja .vjs-progress-control {
+    display: block !important;
+    visibility: visible !important;
+    opacity: 1 !important;
+    pointer-events: auto !important;
+    z-index: 117;
+    flex-grow: 1;
+}
+
+.tiktok-symulacja .vjs-progress-holder {
+    display: block !important;
+    visibility: visible !important;
+    opacity: 1 !important;
+    pointer-events: auto !important;
+    z-index: 117;
+}
+
 .tiktok-symulacja .vjs-play-progress {
     display: block !important;
     visibility: visible !important;
     opacity: 1 !important;
     pointer-events: auto !important;
-    z-index: 117; /* Ustaw wyższy z-index, aby być nad nakładką secret-overlay */
-}
-
-/* Make the progress bar fill the width of the control bar */
-.tiktok-symulacja .vjs-progress-control {
-    flex-grow: 1;
-}
-
-/* Style the progress bar itself */
-.tiktok-symulacja .vjs-play-progress {
+    z-index: 117;
     background: linear-gradient(90deg, #00AEEF, #0089D1);
     box-shadow: 0 0 8px rgba(0, 174, 239, 0.5);
     border-radius: 0;


### PR DESCRIPTION
This commit implements a robust solution to make the video progress bar visible on "secret" slides for non-logged-in users, while still hiding the video content.

This was achieved through a combination of JavaScript and CSS changes:

1.  **JavaScript (`script.js`):**
    - Modified the `_attachSrc` function in `VideoManager` to always initialize the `video.js` player for every slide, ensuring the control elements are created in the DOM.
    - For secret slides viewed by non-logged-in users, the video source is not attached. Instead, the `vjs-has-started` class is programmatically added to the player. This tricks the Video.js library into displaying the control bar even without a loaded video.

2.  **CSS (`style.css`):**
    - Added CSS rules to force the visibility of the progress bar and its components, ensuring they have a high `z-index` to appear above the "secret" overlay.
    - Refactored and consolidated the progress bar styles to remove redundancy and improve code clarity, addressing feedback from a previous code review.