### PR TITLE
Fix: Make progress bar visible on secret slides

### DIFF
--- a/style.css
+++ b/style.css
@@ -2056,3 +2056,12 @@
 .tiktok-symulacja .vjs-remaining-time-display {
     display: none !important;
 }
+
+/* Custom fix for the progress bar on secret slides */
+.tiktok-symulacja .videoPlayer.secret-active .vjs-progress-control {
+    pointer-events: none !important;
+}
+
+.tiktok-symulacja .videoPlayer.secret-active .vjs-progress-holder {
+    background-color: rgba(255, 255, 255, 0.4);
+}


### PR DESCRIPTION
On slides with "top secret" content, the video progress bar was completely invisible because there was no video to load, and the default Video.js styles do not provide a background for an empty bar.

This change adds custom CSS to:
- Set a background color for the progress bar holder on secret slides, making it visible even when empty.
- Disable pointer events on the progress bar for secret slides, as there is no video to interact with.

This ensures the UI remains consistent and the progress bar is always visible, indicating the presence of the video player component.