### PR TITLE
Fix: Always show PWA install bar on mobile

### DIFF
--- a/script.js
+++ b/script.js
@@ -879,7 +879,12 @@
                     return;
                 }
 
-                // For browsers that support `beforeinstallprompt`
+                // For mobile browsers, always show the installation bar.
+                if (!isDesktop()) {
+                    showInstallBar();
+                }
+
+                // For browsers that support `beforeinstallprompt` (like Chrome on Android)
                 if ('onbeforeinstallprompt' in window) {
                     window.addEventListener('beforeinstallprompt', (e) => {
                         e.preventDefault();
@@ -887,21 +892,13 @@
                         if (installButton) {
                             installButton.disabled = false;
                         }
-                        showInstallBar();
                     });
 
                     window.addEventListener('appinstalled', () => {
                         console.log('PWA was installed');
-                        // Hide prompt, nullify event, and update UI to installed state
                         installPromptEvent = null;
                         updateBarToInstalledState();
                     });
-                }
-                // Fallback for browsers that don't support it (e.g. iOS)
-                else {
-                    if(isIOS()) {
-                        showInstallBar();
-                    }
                 }
 
 


### PR DESCRIPTION
The PWA installation bar was previously only shown on Android when the `beforeinstallprompt` event fired. This event does not fire if the app is already installed, causing the bar to disappear for users revisiting the site in the browser.

This change modifies the logic to:
- Unconditionally display the install bar on all mobile browsers (`!isDesktop()`).
- Retain the `beforeinstallprompt` event listener to handle the actual installation process.
- Clean up redundant code for iOS and the `beforeinstallprompt` listener.

This ensures the bar is always visible on mobile, as requested.