### PR TITLE
feat: Replace login panel with new form and mock login functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,11 @@
             <button class="topbar-icon-btn notification-bell" data-action="toggle-notifications" data-translate-aria-label="notificationAriaLabel" aria-label="Powiadomienia"><svg viewBox="0 0 24 24" width="22" height="22" aria-hidden="true"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M13.73 21a2 2 0 0 1-3.46 0" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg><div class="notification-dot"></div></button>
         </div>
         <div class="login-panel" aria-hidden="true">
+                <form id="tt-login-form" class="login-form">
+                    <input type="text" id="tt-username" aria-label="Username" />
+                    <input type="password" id="tt-password" aria-label="Password" />
+                    <button type="submit" id="tt-login-submit">ENTER</button>
+                </form>
             </div>
         <div class="logged-in-menu" aria-hidden="true">
             <a href="#" data-action="open-account-modal" class="accountMenuButton" data-translate-key="accountMenuButton">Konto</a>
@@ -362,7 +367,6 @@
     <div class="crop-modal" id="cropModal">
         </div>
     <input type="file" class="file-input" id="avatarFileInput" accept="image/*">
-    <div id="um-login-render-container" style="display: none;">[tt_login_form]</div>
 
     <div id="pwa-install-bar" class="pwa-prompt">
         <div class="pwa-prompt-content">

--- a/style.css
+++ b/style.css
@@ -630,37 +630,35 @@
         .login-panel.active {
             max-height: 500px;
         }
-        .login-panel > div {
-            padding: 20px 25px;
+        .login-panel > div, .login-panel > form {
+            padding: 20px 15px;
             background: transparent !important;
         }
-        .login-panel form {
-            margin-bottom: 0 !important;
-            padding-bottom: 0 !important;
+        .login-panel .login-form {
+            background: white;
+            padding: 20px;
+            border-radius: 8px;
             display: flex;
             flex-direction: column;
-            gap: 8px;
-        }
-        .login-panel form p {
-            margin: 0;
+            gap: 15px;
+            width: 95%;
+            margin: 0 auto;
         }
 
-        /* === LOGIN PANEL RETRO HACKER STYLE === */
-        .login-panel form input[type="text"],
-        .login-panel form input[type="password"],
-        .login-panel form input[type="email"] {
+        /* === LOGIN PANEL NEW STYLE === */
+        .login-panel .login-form input[type="text"],
+        .login-panel .login-form input[type="password"] {
             background: white;
             border: 2px solid black;
-            font-family: "Courier New", monospace;
             font-weight: bold;
             color: black;
-            padding: 10px;
+            padding: 12px 10px;
             border-radius: 4px;
             width: 100%;
-            margin-bottom: 0; /* Use flex gap for spacing */
+            font-size: 16px;
         }
 
-        .login-panel form input[type="submit"] {
+        .login-panel .login-form button[type="submit"] {
             background: black;
             border: none;
             width: 100%;
@@ -673,9 +671,10 @@
             -webkit-appearance: none;
             appearance: none;
             border-radius: 4px;
+            font-size: 16px;
         }
 
-        .login-panel form input[type="submit"]:active {
+        .login-panel .login-form button[type="submit"]:active {
             background: #222;
         }
 


### PR DESCRIPTION
- Replaces the shortcode-based login form with a new, hardcoded HTML form in `index.html`.
- Styles the new form to be nearly full-width with a white background, bold input borders, and a full-width 'ENTER' button, as per requirements.
- Removes the old `initGlobalPanels` JavaScript function that handled the previous form.
- Repurposes the 'OCB' / 'Info' button to be a mock login/logout toggle.
- Creates a `mockToggleLogin` function to handle the new login state toggling, UI updates, and user alerts.
- Wires both the 'OCB' button and the new form's 'ENTER' button to the `mockToggleLogin` function.