### PR TITLE
Fix: Make account modal overlay transparent

### DIFF
--- a/style.css
+++ b/style.css
@@ -1049,7 +1049,7 @@
             left: 0;
             width: 100%;
             height: 100vh;
-            background: #000000;
+            background: transparent;
             z-index: 2000;
             opacity: 0;
             visibility: hidden;


### PR DESCRIPTION
This change makes the account modal overlay transparent, so that the main feed remains visible when the modal slides in.