### PR TITLE
feat: Update profile modal UI and animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,7 +221,7 @@
                                 <svg class="badge-icon" fill="currentColor" viewBox="0 0 24 24">
                                     <path d="M12 2L15.09 8.26L22 9L17 14L18.18 21L12 17.77L5.82 21L7 14L2 9L8.91 8.26L12 2Z"/>
                                 </svg>
-                                Patron
+                                Patron Miłości
                             </div>
                         </div>
                     </div>

--- a/script.js
+++ b/script.js
@@ -1366,7 +1366,30 @@
 
             function closeAccountModal() {
                 const modal = document.getElementById('accountModal');
-                modal.classList.remove('visible');
+                const modalContent = modal.querySelector('.account-modal-content');
+
+                // Do nothing if the modal is not visible or is already closing.
+                if (!modal.classList.contains('visible') || modal.classList.contains('is-hiding')) {
+                    return;
+                }
+
+                const onTransitionEnd = (event) => {
+                    // Ensure we're reacting to the end of the transform on the correct element.
+                    if (event.target === modalContent && event.propertyName === 'transform') {
+                        modal.classList.remove('visible');
+                        modal.classList.remove('is-hiding');
+                        // Clean up the event listener.
+                        modalContent.removeEventListener('transitionend', onTransitionEnd);
+                    }
+                };
+
+                modalContent.addEventListener('transitionend', onTransitionEnd);
+
+                // Add the is-hiding class to trigger the closing animation.
+                // The .visible class remains for now, so the overlay is still visible during the animation.
+                modal.classList.add('is-hiding');
+
+                // Restore body scrolling immediately.
                 document.body.style.overflow = '';
             }
 

--- a/style.css
+++ b/style.css
@@ -1076,6 +1076,10 @@
             transform: translateX(0);
         }
 
+        .account-modal-overlay.is-hiding .account-modal-content {
+            transform: translateX(-100%);
+        }
+
         .account-header {
             position: relative;
             height: var(--topbar-height);
@@ -1155,7 +1159,7 @@
 
         .tab-btn.active {
             color: #fff;
-            background: transparent;
+            background: rgba(255, 255, 255, 0.08);
             border-bottom-color: var(--accent-color);
         }
 
@@ -1433,7 +1437,7 @@
 
         .btn-primary {
             background: linear-gradient(135deg, #ff0055, #ff4081);
-            border: 2px solid white;
+            border: 1px solid rgba(255, 255, 255, 0.8);
             padding: 14px 24px;
             border-radius: 12px;
             color: #fff;


### PR DESCRIPTION
This commit addresses four UI improvements for the account profile modal:

1.  Thins the border on primary buttons to 1px with reduced opacity for a more refined look.
2.  Implements a slide-out animation for the modal, making its closing behavior match its opening animation. This is achieved by adding a temporary `is-hiding` class and using a `transitionend` event listener to manage state.
3.  Adds a subtle dark grey background to active tabs to improve their visibility.
4.  Updates the 'Patron' badge text to 'Patron Miłości' as requested.