### PR TITLE
Fix PWA install button behavior and adjust notification modal

### DIFF
--- a/script.js
+++ b/script.js
@@ -815,6 +815,13 @@
                 if (iosInstructions) iosInstructions.classList.remove('visible');
             }
 
+            function updatePwaUiForInstalledState() {
+                if (!installBar || !installButton) return;
+                installButton.disabled = true;
+                installButton.textContent = Utils.getTranslation('installPwaAction');
+                installBar.classList.add('installed');
+            }
+
             function showDesktopModal() {
                 if (desktopModal) UI.openModal(desktopModal);
             }
@@ -822,21 +829,6 @@
             function closePwaModals() {
                 if (desktopModal && desktopModal.classList.contains('visible')) UI.closeModal(desktopModal);
                 if (iosInstructions && iosInstructions.classList.contains('visible')) hideIosInstructions();
-            }
-
-            function updateBarToInstalledState() {
-                if (!installBar || !installButton) return;
-
-                const title = installBar.querySelector('.pwa-prompt-title');
-                const description = installBar.querySelector('.pwa-prompt-description');
-
-                if (title) title.style.display = 'none';
-                if (description) description.style.display = 'none';
-
-                installButton.textContent = Utils.getTranslation('openPwaAction');
-
-                // Ensure the bar is visible to show the "Open" button.
-                showInstallBar();
             }
 
             function showInstallBar() {
@@ -867,11 +859,9 @@
                     installButton.addEventListener('click', handleInstallClick);
                 }
 
-                // If running in standalone PWA mode, hide the install bar completely.
+                // If running in standalone PWA mode, update the UI to show the installed state.
                 if (isStandalone()) {
-                    if (installBar) {
-                        installBar.style.display = 'none';
-                    }
+                    updatePwaUiForInstalledState();
                     // Do not set up other install listeners if already installed.
                     return;
                 }
@@ -894,7 +884,7 @@
                     window.addEventListener('appinstalled', () => {
                         console.log('PWA was installed');
                         installPromptEvent = null;
-                        updateBarToInstalledState();
+                        updatePwaUiForInstalledState();
                     });
                 }
 
@@ -906,7 +896,7 @@
             }
 
             function handleInstallClick() {
-                // This check is redundant if init() returns early, but good for safety.
+                // Check if the app is already installed and show an alert.
                 if (isStandalone()) {
                     UI.showAlert(Utils.getTranslation('alreadyInstalledText'));
                     return;

--- a/style.css
+++ b/style.css
@@ -873,7 +873,7 @@
            ========================================================================== */
         .notification-popup {
             position: fixed;
-            top: calc(var(--topbar-base-height) / 2 + var(--safe-area-top));
+            top: calc(var(--safe-area-top) + 10px);
             left: 50%;
             width: 350px;
             max-width: calc(100vw - 20px);
@@ -2078,4 +2078,20 @@
     display: block !important;
     visibility: visible !important;
     opacity: 1 !important;
+}
+
+/* Styles for installed PWA bar */
+#pwa-install-bar.installed .pwa-prompt-button {
+    cursor: not-allowed;
+    background-color: #555;
+    pointer-events: none;
+}
+
+#pwa-install-bar.installed .pwa-prompt-description {
+    font-size: 0;
+}
+
+#pwa-install-bar.installed .pwa-prompt-description::before {
+    content: "Aplikacja jest już zainstalowana.";
+    font-size: 0.9rem;
 }


### PR DESCRIPTION
- The PWA install button is now disabled and displays a message when the app is already installed, instead of changing to an "Open" button.
- The notification modal has been moved up slightly to cover the top bar text as requested.

Changes made:
- Modified `script.js` to update PWA state handling.
- Added CSS in `style.css` for the "installed" state of the PWA bar.
- Adjusted the `top` property for the notification popup in `style.css`.