### PR TITLE
feat: Display PWA install banner on desktop

### DIFF
--- a/script.js
+++ b/script.js
@@ -865,9 +865,7 @@
                 }
 
                 // For mobile browsers, always show the installation bar.
-                if (!isDesktop()) {
-                    showInstallBar();
-                }
+                showInstallBar();
 
                 // For browsers that support `beforeinstallprompt` (like Chrome on Android)
                 if ('onbeforeinstallprompt' in window) {
@@ -914,6 +912,8 @@
                 } else if (isIOS()) {
                     // On iOS, we show instructions.
                     showIosInstructions();
+                } else if (isDesktop()) {
+                    showDesktopModal();
                 } else {
                     // If not on iOS and there's no prompt, the app is likely installed.
                     UI.showAlert(Utils.getTranslation('alreadyInstalledText'));


### PR DESCRIPTION
This change enables the PWA installation banner to be displayed on desktop devices, not just on mobile.

- The `!isDesktop()` check in the `PWA.init()` function has been removed, allowing the installation bar to be shown on all devices.
- The `handleInstallClick()` function has been updated to provide a better user experience on desktop browsers that do not support direct PWA installation. In such cases, a modal with a QR code is now displayed, guiding the user to install the app on their mobile device.