### PR TITLE
Fix: Adjust styling of login panel and overlays

### DIFF
--- a/style.css
+++ b/style.css
@@ -240,7 +240,7 @@
             top: var(--topbar-height); /* Start below top bar */
             left: 0;
             width: 100%;
-            height: calc(100% - var(--topbar-height)); /* Fill remaining space */
+            height: calc(100% - var(--topbar-height) - var(--bottombar-height)); /* Fill space between bars */
             background: rgba(0,0,0,0.4);
             -webkit-backdrop-filter: blur(12px) saturate(120%);
             backdrop-filter: blur(12px) saturate(120%);
@@ -648,7 +648,7 @@
             gap: 12px;
             width: 100%;
             max-width: 400px;
-            margin: 0 auto;
+            margin: -10px auto 0;
         }
 
         /* === LOGIN PANEL NEW STYLE === */
@@ -658,7 +658,7 @@
             border: 2px solid black;
             font-weight: bold;
             color: black;
-            padding: 12px 10px;
+            padding: 8px 10px;
             border-radius: 4px;
             width: 100%;
             font-size: 16px;
@@ -668,11 +668,11 @@
             background: var(--accent-color);
             border: none;
             width: 100%;
-            padding: 14px;
+            padding: 10px;
             font-weight: bold;
             color: white;
             text-transform: uppercase;
-            font-family: "Courier New", monospace;
+            font-family: inherit;
             cursor: pointer;
             -webkit-appearance: none;
             appearance: none;


### PR DESCRIPTION
This commit addresses several styling issues to improve the user interface.

-   **Login Panel:**
    -   Reduced the height of the login form input fields and the "ENTER" button by adjusting their vertical padding.
    -   Moved the login form closer to the top bar by applying a negative margin.
    -   Changed the "ENTER" button's font to `inherit` to ensure it matches the application's default font style.

-   **"Top Secret" Overlays:**
    -   Vertically centered the "scisle tajne" (top secret) overlays within the available space between the top and bottom bars. This was achieved by modifying the overlay's height calculation, allowing the existing flexbox properties to center the content correctly.