### PR TITLE
Fix: Adjust comments modal styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,10 +170,12 @@
     </div>
     <div id="commentsModal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="commentsTitle" aria-hidden="true">
         <div class="modal-content" tabindex="-1">
-            <button class="modal-close-btn" data-translate-aria-label="closeCommentsAriaLabel" aria-label="Zamknij komentarze">&times;</button>
-            <h2 id="commentsTitle" data-translate-key="commentsModalTitle">Komentarze</h2>
+            <div class="modal-header">
+                <h2 id="commentsTitle" data-translate-key="commentsModalTitle">Komentarze</h2>
+                <button class="modal-close-btn" data-translate-aria-label="closeCommentsAriaLabel" aria-label="Zamknij komentarze">&times;</button>
+            </div>
             <div class="modal-body">
-                </div>
+            </div>
         </div>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -847,6 +847,7 @@
         /* Modal: Comments */
         #commentsModal.modal-overlay {
             align-items: flex-end;
+            z-index: 10005;
         }
         #commentsModal .modal-content {
             background: white;
@@ -855,17 +856,39 @@
             max-width: 100%;
             height: 75vh;
             border-radius: 16px 16px 0 0;
-            padding: 20px;
+            padding: 12px;
             transform: translateY(100%);
             transition: transform 0.3s ease-out;
+            display: flex;
+            flex-direction: column;
         }
         #commentsModal.visible .modal-content {
             transform: translateY(0);
         }
-        #commentsModal .modal-close-btn { color: #111; }
+        #commentsModal .modal-header {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            position: relative;
+            padding: 8px 0;
+            flex-shrink: 0;
+        }
+        #commentsModal h2 {
+            margin: 0;
+            font-size: 16px;
+            font-weight: 600;
+        }
+        #commentsModal .modal-close-btn {
+            color: #111;
+            position: absolute;
+            top: 50%;
+            right: 4px;
+            transform: translateY(-50%);
+        }
         #commentsModal .modal-body {
-            height: calc(100% - 60px);
+            height: 100%;
             overflow-y: auto;
+            padding: 12px;
         }
 
         /* ==========================================================================


### PR DESCRIPTION
- Increases the z-index of the comments modal to ensure it appears above the PWA installation bar.
- Centers the title within the modal header.
- Repositions the close button to be more aesthetically placed in the corner of the modal header.
- Adds a `.modal-header` div to the HTML to properly structure the header for styling.