### PR TITLE
feat: Update notification header layout and topbar font style

### DIFF
--- a/style.css
+++ b/style.css
@@ -342,8 +342,8 @@
             position: relative;
         }
         .topbar-text {
-            font-size: 14px;
-            font-weight: 500;
+            font-size: 16px;
+            font-weight: 600;
             color: white;
             pointer-events: none;
         }
@@ -925,13 +925,14 @@
         }
         .notification-header {
             display: flex;
-            justify-content: space-between;
+            justify-content: center;
             align-items: center;
             padding: 12px 16px;
             border-bottom: 1px solid rgba(255, 255, 255, 0.1);
             font-weight: 600;
             font-size: 16px;
             flex-shrink: 0;
+            position: relative;
         }
         .notification-header button {
             background: none;
@@ -943,6 +944,10 @@
             cursor: pointer;
             opacity: 0.7;
             transition: opacity 0.2s;
+            position: absolute;
+            right: 16px;
+            top: 50%;
+            transform: translateY(-50%);
         }
         .notification-header button:hover { opacity: 1; }
         .notification-list {


### PR DESCRIPTION
This commit includes two UI improvements:

1.  Notification Modal Header:
    - Centers the 'Powiadomienia' title.
    - Repositions the 'X' close button to the top-right corner for a more standard and aesthetic layout.

2.  Top Bar Text:
    - Adjusts the font size and weight of the main top bar text ('Nie masz psychy' / 'Ting Tong') to be consistent with other headers, such as the one in the account modal.
    - Font size is changed from 14px to 16px.
    - Font weight is changed from 500 to 600.