### PR TITLE
fix: Use CORS proxy for HLS video streams

### DIFF
--- a/script.js
+++ b/script.js
@@ -161,13 +161,15 @@
             window.TingTongData = {
                 isLoggedIn: false, // Start as logged out
                 slides: [
+                    // PATCH: Dodano proxy CORS, aby umożliwić odtwarzanie strumieni HLS z zewnętrznych serwerów.
+                    // Przeglądarki (poza Safari) blokują takie żądania bez odpowiednich nagłówków CORS.
                     {
                         'id': 'slide-001',
                         'likeId': '1',
                         'user': 'Unified Streaming',
                         'description': 'Tears of Steel - HLS (ISM)',
                         'mp4Url': 'https://pawelperfect.pl/wp-content/uploads/2025/07/17169505-hd_1080_1920_30fps.mp4',
-                        'hlsUrl': 'https://live-hls-abr-cdn.livepush.io/live/bigbuckbunnyclip/index.m3u8',
+                        'hlsUrl': 'https://proxy.cors.sh/https://live-hls-abr-cdn.livepush.io/live/bigbuckbunnyclip/index.m3u8',
                         'poster': '',
                         'avatar': 'https://i.pravatar.cc/100?u=unified',
                         'access': 'public',
@@ -181,7 +183,7 @@
                         'user': 'Apple',
                         'description': 'BipBop - HLS (fMP4)',
                         'mp4Url': 'https://pawelperfect.pl/wp-content/uploads/2025/07/17169505-hd_1080_1920_30fps.mp4',
-                        'hlsUrl': 'https://moctobpltc-i.akamaihd.net/hls/live/571329/eight/playlist.m3u8',
+                        'hlsUrl': 'https://proxy.cors.sh/https://moctobpltc-i.akamaihd.net/hls/live/571329/eight/playlist.m3u8',
                         'poster': '',
                         'avatar': 'https://i.pravatar.cc/100?u=apple',
                         'access': 'secret',
@@ -195,7 +197,7 @@
                         'user': 'Unified Streaming',
                         'description': 'Tears of Steel - HLS (MP4)',
                         'mp4Url': 'https://pawelperfect.pl/wp-content/uploads/2025/07/17169505-hd_1080_1920_30fps.mp4',
-                        'hlsUrl': 'https://cph-p2p-msl.akamaized.net/hls/live/2000341/test/master.m3u8',
+                        'hlsUrl': 'https://proxy.cors.sh/https://cph-p2p-msl.akamaized.net/hls/live/2000341/test/master.m3u8',
                         'poster': '',
                         'avatar': 'https://i.pravatar.cc/100?u=unified2',
                         'access': 'pwa',


### PR DESCRIPTION
The HLS video streams were failing to load in most browsers due to missing CORS (Cross-Origin Resource Sharing) headers from the external video servers.

This change prepends a public CORS proxy (`https://proxy.cors.sh/`) to the HLS URLs in the mock data. The proxy adds the necessary `Access-Control-Allow-Origin` headers to the responses, allowing the video player to fetch and play the streams correctly.