### PR TITLE
feat: Add self-hosted CORS proxy for HLS streams

### DIFF
--- a/api/proxy.js
+++ b/api/proxy.js
@@ -1,0 +1,50 @@
+module.exports = async (request, response) => {
+  const targetUrl = request.query.url;
+
+  if (!targetUrl) {
+    return response.status(400).send('Error: "url" query parameter is required.');
+  }
+
+  // Preflight-Anfrage für CORS abhandeln
+  if (request.method === 'OPTIONS') {
+    response.setHeader('Access-Control-Allow-Origin', '*');
+    response.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+    response.setHeader('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+    return response.status(200).end();
+  }
+
+  try {
+    const fetchResponse = await fetch(targetUrl, {
+      headers: {
+        'User-Agent': 'TingTongVercelProxy/1.0',
+      },
+      redirect: 'follow' // HLS-Manifeste können Weiterleitungen enthalten
+    });
+
+    if (!fetchResponse.ok) {
+      // Den Fehlertext vom Zielserver an den Client weiterleiten
+      const errorText = await fetchResponse.text();
+      return response.status(fetchResponse.status).send(`Error from target server: ${errorText}`);
+    }
+
+    // Setze die CORS-Header für die eigentliche Antwort
+    response.setHeader('Access-Control-Allow-Origin', '*');
+
+    // Leite die Header vom Zielserver an den Client weiter
+    // Wichtig für Content-Type, Content-Length etc.
+    fetchResponse.headers.forEach((value, name) => {
+      // Überschreibe den CORS-Header nicht, falls er vom Zielserver kommt
+      if (name.toLowerCase() !== 'access-control-allow-origin') {
+        response.setHeader(name, value);
+      }
+    });
+
+    // Leite den Body als Stream weiter
+    const bodyStream = fetchResponse.body;
+    bodyStream.pipe(response);
+
+  } catch (error) {
+    console.error('Proxy-Fehler:', error);
+    response.status(500).send(`Proxy Error: ${error.message}`);
+  }
+};

--- a/script.js
+++ b/script.js
@@ -161,15 +161,13 @@
             window.TingTongData = {
                 isLoggedIn: false, // Start as logged out
                 slides: [
-                    // PATCH: Dodano proxy CORS, aby umożliwić odtwarzanie strumieni HLS z zewnętrznych serwerów.
-                    // Przeglądarki (poza Safari) blokują takie żądania bez odpowiednich nagłówków CORS.
                     {
                         'id': 'slide-001',
                         'likeId': '1',
                         'user': 'Unified Streaming',
                         'description': 'Tears of Steel - HLS (ISM)',
                         'mp4Url': 'https://pawelperfect.pl/wp-content/uploads/2025/07/17169505-hd_1080_1920_30fps.mp4',
-                        'hlsUrl': 'https://proxy.cors.sh/https://live-hls-abr-cdn.livepush.io/live/bigbuckbunnyclip/index.m3u8',
+                        'hlsUrl': 'https://live-hls-abr-cdn.livepush.io/live/bigbuckbunnyclip/index.m3u8',
                         'poster': '',
                         'avatar': 'https://i.pravatar.cc/100?u=unified',
                         'access': 'public',
@@ -183,7 +181,7 @@
                         'user': 'Apple',
                         'description': 'BipBop - HLS (fMP4)',
                         'mp4Url': 'https://pawelperfect.pl/wp-content/uploads/2025/07/17169505-hd_1080_1920_30fps.mp4',
-                        'hlsUrl': 'https://proxy.cors.sh/https://moctobpltc-i.akamaihd.net/hls/live/571329/eight/playlist.m3u8',
+                        'hlsUrl': 'https://moctobpltc-i.akamaihd.net/hls/live/571329/eight/playlist.m3u8',
                         'poster': '',
                         'avatar': 'https://i.pravatar.cc/100?u=apple',
                         'access': 'secret',
@@ -197,7 +195,7 @@
                         'user': 'Unified Streaming',
                         'description': 'Tears of Steel - HLS (MP4)',
                         'mp4Url': 'https://pawelperfect.pl/wp-content/uploads/2025/07/17169505-hd_1080_1920_30fps.mp4',
-                        'hlsUrl': 'https://proxy.cors.sh/https://cph-p2p-msl.akamaized.net/hls/live/2000341/test/master.m3u8',
+                        'hlsUrl': 'https://cph-p2p-msl.akamaized.net/hls/live/2000341/test/master.m3u8',
                         'poster': '',
                         'avatar': 'https://i.pravatar.cc/100?u=unified2',
                         'access': 'pwa',
@@ -675,7 +673,10 @@
                     const sources = [];
                     const useHls = Config.USE_HLS && slideData.hlsUrl;
                     if (useHls) {
-                        sources.push({ src: slideData.hlsUrl, type: 'application/x-mpegURL' });
+                        // PATCH: Użyj lokalnego proxy CORS, aby ominąć ograniczenia przeglądarki.
+                        // URL jest kodowany, aby zapewnić poprawne przekazanie jako parametr zapytania.
+                        const proxiedHlsUrl = `/api/proxy?url=${encodeURIComponent(slideData.hlsUrl)}`;
+                        sources.push({ src: proxiedHlsUrl, type: 'application/x-mpegURL' });
                         if (slideData.mp4Url) sources.push({ src: slideData.mp4Url, type: 'video/mp4' });
                     } else if (slideData.mp4Url) {
                         sources.push({ src: slideData.mp4Url, type: 'video/mp4' });

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "api/proxy.js": {
+      "memory": 128
+    }
+  }
+}


### PR DESCRIPTION
External HLS video streams were failing to load due to browser CORS restrictions. Public proxies proved to be unreliable or blocked by the video hosts.

This commit introduces a self-hosted CORS proxy using a Vercel Serverless Function.

- Adds `api/proxy.js` to handle fetching and proxying the HLS manifests and segments.
- Adds `vercel.json` to configure the serverless function.
- Modifies `script.js` to dynamically route all HLS requests through this new proxy endpoint.

This provides a robust and reliable solution to the video playback issue.