### PR TITLE
fix: Correct HLS stream handling in CORS proxy

### DIFF
--- a/api/proxy.js
+++ b/api/proxy.js
@@ -40,8 +40,11 @@ module.exports = async (request, response) => {
     });
 
     // Leite den Body als Stream weiter
+    // PATCH: Konvertiere den Web-Stream (von fetch) in einen Node.js-Stream, um ihn korrekt an die Antwort zu pipen.
+    // Die direkte Verwendung von .pipe() ist bei Web-Streams nicht mit Node-Server-Antworten kompatibel.
+    const { Readable } = require('stream');
     const bodyStream = fetchResponse.body;
-    bodyStream.pipe(response);
+    Readable.fromWeb(bodyStream).pipe(response);
 
   } catch (error) {
     console.error('Proxy-Fehler:', error);


### PR DESCRIPTION
The previous self-hosted proxy implementation was causing a "format not supported" error in the video player. This was due to an incorrect method of piping the video stream, which likely led to data corruption.

This commit fixes the streaming logic within the `api/proxy.js` serverless function. It now correctly converts the Web API `ReadableStream` from `fetch` into a Node.js `Readable` stream using `Readable.fromWeb()` before piping it to the response.

This ensures that the HLS manifest and segments are streamed without corruption, resolving the playback issue.