### PR TITLE
Fix: Resolve critical Swiper initialization race condition

### DIFF
--- a/script.js
+++ b/script.js
@@ -671,19 +671,20 @@
             return {
                 init: () => {
                     // Slides are already rendered by UI.renderSlides()
-                    swiper = new Swiper('.swiper', {
+                    new Swiper('.swiper', {
                         direction: 'vertical',
                         mousewheel: true,
                         loop: true,
                         keyboard: true,
                         on: {
-                            init: (swiper) => {
+                            init: function () {
+                                 swiper = this; // Assign the swiper instance to the closure variable
                                  // Odtwórz tylko początkowy slajd po inicjalizacji
-                                 const initialSlideEl = swiper.slides[swiper.realIndex];
+                                 const initialSlideEl = this.slides[this.realIndex];
                                  if (initialSlideEl) {
                                      const slideId = initialSlideEl.dataset.slideId;
                                      if (!players[slideId]) {
-                                         loadPlayerForSlide(swiper.realIndex);
+                                         loadPlayerForSlide(this.realIndex);
                                      } else {
                                          players[slideId].play();
                                      }


### PR DESCRIPTION
This commit provides a definitive fix for the `TypeError: Cannot read properties of undefined (reading 'slides')` that caused the application to crash on startup.

The root cause was a race condition where functions like `loadPlayerForSlide` were called during Swiper's initialization, attempting to use the `swiper` module-scoped variable before the `new Swiper()` constructor had completed and assigned the instance to it.

The fix is implemented in the `VideoManager.init` function:
- The `swiper` variable is now assigned inside the `on: { init: function() { ... } }` handler using `swiper = this;`.
- This ensures that the `swiper` variable is set and available at the exact moment the `init` event fires, before any other functions that depend on it are called.

This targeted change resolves the startup crash and allows the application to launch reliably.