### PR TITLE
Fix regression where the application would not load.

### DIFF
--- a/script.js
+++ b/script.js
@@ -1295,6 +1295,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // Main initialization function
         function init() {
+            const accountModal = document.getElementById('accountModal');
+            if (!accountModal) {
+                // Silently return if the account panel is not part of the DOM.
+                // This allows the rest of the app to function without the account features.
+                return;
+            }
             initializeModal();
             initializeCropper();
             setupEventListeners();


### PR DESCRIPTION
Added a defensive check to the `AccountPanel.init` function. This prevents a script-halting error when the account panel's HTML elements are not present in the DOM, which was blocking the preloader and language selection from appearing.