### PR TITLE
Remove setTimeout from preloader initialization.

### DIFF
--- a/script.js
+++ b/script.js
@@ -1914,7 +1914,6 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         function _initializePreloader() {
-            setTimeout(() => UI.DOM.preloader.classList.add('content-visible'), 500);
             UI.DOM.preloader.querySelectorAll('.language-selection button').forEach(button => {
                 button.addEventListener('click', () => {
                     UI.DOM.preloader.querySelectorAll('.language-selection button').forEach(btn => btn.disabled = true);


### PR DESCRIPTION
The 500ms delay was causing a synchronization issue that prevented the language selection panel from being displayed, blocking the application from loading. Removing the timeout ensures the panel is visible immediately.