### PR TITLE
Fix: Make language selection panel visible on load

### DIFF
--- a/script.js
+++ b/script.js
@@ -1924,6 +1924,9 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         function _initializePreloader() {
+            // Spraw, aby kontener wyboru języka był widoczny
+            UI.DOM.preloader.classList.add('content-visible');
+
             UI.DOM.preloader.querySelectorAll('.language-selection button').forEach(button => {
                 button.addEventListener('click', () => {
                     UI.DOM.preloader.querySelectorAll('.language-selection button').forEach(btn => btn.disabled = true);


### PR DESCRIPTION
The language selection panel was not visible because the `content-visible` class was not being added to the preloader element.

This change adds the necessary class `content-visible` to the preloader element inside the `_initializePreloader` function, ensuring the panel is displayed as intended when the application starts.