### PR TITLE
Fix: Reintroduce delay for language panel animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -1925,7 +1925,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         function _initializePreloader() {
             // Spraw, aby kontener wyboru języka był widoczny
-            UI.DOM.preloader.classList.add('content-visible');
+            setTimeout(() => UI.DOM.preloader.classList.add('content-visible'), 500);
 
             UI.DOM.preloader.querySelectorAll('.language-selection button').forEach(button => {
                 button.addEventListener('click', () => {


### PR DESCRIPTION
The language selection panel was not appearing because the `content-visible` class was being added immediately on page load. This prevented the browser from registering the initial hidden state, which in turn prevented the CSS animation from running correctly.

This change reintroduces a 500ms `setTimeout` delay before adding the `content-visible` class to the preloader element. This ensures that the browser has enough time to apply the initial styles, allowing the animation to trigger as expected and making the panel visible.