### PR TITLE
fix: Enable swiping on iframe slides

### DIFF
--- a/style.css
+++ b/style.css
@@ -214,6 +214,12 @@
             z-index: 1;
             font-family: 'Manrope', sans-serif;
         }
+        .tiktok-symulacja iframe {
+            width: 100%;
+            height: 100%;
+            border: none;
+            pointer-events: none;
+        }
         .tiktok-symulacja * {
             box-sizing: border-box;
             -webkit-tap-highlight-color: transparent;

--- a/style.css
+++ b/style.css
@@ -218,7 +218,7 @@
             width: 100%;
             height: 100%;
             border: none;
-            pointer-events: none;
+            pointer-events: none !important;
         }
         .tiktok-symulacja * {
             box-sizing: border-box;


### PR DESCRIPTION
Adds a CSS rule to set 'pointer-events: none' on iframes within slides. This prevents the iframe from capturing touch events, allowing the user to swipe between slides.

This also includes the initial commit for adding the two video slides.