### PR TITLE
feat: Replace video player with a simpler, native HTML5 implementation

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,12 +39,9 @@
     <link rel="dns-prefetch" href="//i.pravatar.cc">
 
     <script data-name="BMC-Widget" data-cfasync="false" src="https://cdnjs.buymeacoffee.com/1.0.0/widget.prod.min.js" data-id="pawelperfect" data-description="Support me on Buy me a coffee!" data-message="" data-color="#FF5F5F" data-position="Right" data-x_margin="18" data-y_margin="18"></script>
-    <link rel="stylesheet" href="https://cdn.plyr.io/3.7.8/plyr.css" />
     <link rel="stylesheet" href="style.css">
     <link rel="manifest" href="manifest.json">
     <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js" defer></script>
-    <script src="https://cdn.plyr.io/3.7.8/plyr.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/hls.js@latest" defer></script>
     <script src="script.js" defer></script>
 </head>
 <body>


### PR DESCRIPTION
This commit replaces the existing video playback mechanism, which used `plyr.io` and `hls.js`, with a simpler implementation that uses the native HTML5 video element.

The new implementation is based on the logic from `scrollplay.js`, but it has been adapted to work with the Swiper.js-based vertical feed. The video in the active slide now plays automatically, and all other videos are paused.

This change addresses the user's concerns about cross-platform reliability issues with the previous, more complex video player.

Additionally, this commit adds a few new video slides with sample videos from the internet to serve as a prototype, as requested by the user.