### PR TITLE
feat: Add video progress bar to slides

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,6 +120,9 @@
                         </button>
                     </div>
                     <div class="bottombar">
+                        <div class="progress-bar">
+                            <div class="progress-bar-fill"></div>
+                        </div>
                         <div class="text-info">
                             <div class="text-user"></div>
                             <div class="text-description"></div>

--- a/script.js
+++ b/script.js
@@ -484,6 +484,29 @@
                 likeBtn.dataset.likeId = slideData.likeId;
                 updateLikeButtonState(likeBtn, slideData.isLiked, slideData.initialLikes);
 
+                const progressBar = section.querySelector('.progress-bar');
+                const progressBarFill = section.querySelector('.progress-bar-fill');
+
+                if (videoEl && progressBar && progressBarFill) {
+                    videoEl.addEventListener('timeupdate', () => {
+                        if (videoEl.duration > 0) {
+                            const progress = (videoEl.currentTime / videoEl.duration) * 100;
+                            progressBarFill.style.width = `${progress}%`;
+                        }
+                    });
+
+                    progressBar.addEventListener('click', (e) => {
+                        const rect = progressBar.getBoundingClientRect();
+                        const clickX = e.clientX - rect.left;
+                        const width = rect.width;
+                        const duration = videoEl.duration;
+
+                        if (duration > 0) {
+                            videoEl.currentTime = (clickX / width) * duration;
+                        }
+                    });
+                }
+
                 return section;
             }
 

--- a/style.css
+++ b/style.css
@@ -382,6 +382,26 @@
             z-index: 105;
             padding-bottom: calc(10px + var(--safe-area-bottom));
         }
+.progress-bar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 4px;
+    background-color: rgba(255, 255, 255, 0.25);
+    cursor: pointer;
+    transition: height 0.2s ease-in-out;
+}
+.progress-bar:hover {
+    height: 6px;
+}
+.progress-bar-fill {
+    width: 0%;
+    height: 100%;
+    background-color: var(--accent-color);
+    border-radius: 2px;
+    transition: width 0.1s linear;
+}
         .tiktok-symulacja .text-info {
             flex: none;
             min-width: 0;


### PR DESCRIPTION
This commit introduces a progress bar for each video slide.

- The progress bar is added to the top edge of the bottom bar, spanning the full width.
- It visually reflects the current playback time of the video.
- It allows users to seek to different parts of the video by clicking on the bar.
- The implementation involves adding the necessary HTML to the slide template, styling the bar with CSS, and adding JavaScript event listeners to handle the dynamic updates and seeking functionality.