### PR TITLE
fix: Ensure videoEl is defined for progress bar

### DIFF
--- a/script.js
+++ b/script.js
@@ -484,6 +484,7 @@
                 likeBtn.dataset.likeId = slideData.likeId;
                 updateLikeButtonState(likeBtn, slideData.isLiked, slideData.initialLikes);
 
+                const videoEl = section.querySelector('video');
                 const progressBar = section.querySelector('.progress-bar');
                 const progressBarFill = section.querySelector('.progress-bar-fill');
 


### PR DESCRIPTION
This commit fixes a ReferenceError where `videoEl` was not defined in the scope of the progress bar event listeners.

The variable is now correctly queried and defined within the `createSlideElement` function before the event listeners are added, ensuring it is always available.

This resolves the application start-up failure.