### PR TITLE
fix(ui): Ensure progress bar drag state is properly removed

### DIFF
--- a/script.js
+++ b/script.js
@@ -514,37 +514,43 @@
 
                     videoEl.addEventListener('timeupdate', updateProgress);
 
-                    progressBar.addEventListener('click', seek);
-
                     const startDrag = (e) => {
                         isDragging = true;
                         progressBar.classList.add('dragging');
+                        const wasPlaying = !videoEl.paused;
                         videoEl.pause();
-                        seek(e); // Initial seek on click/touch
+
+                        seek(e);
 
                         const onDrag = (moveEvent) => {
                             if (!isDragging) return;
+                            moveEvent.preventDefault();
                             seek(moveEvent);
                         };
 
                         const endDrag = () => {
+                            if (!isDragging) return;
                             isDragging = false;
                             progressBar.classList.remove('dragging');
-                            videoEl.play();
+                            if (wasPlaying) {
+                                videoEl.play().catch(err => {
+                                    console.error("Play failed after drag:", err);
+                                });
+                            }
                             document.removeEventListener('mousemove', onDrag);
                             document.removeEventListener('mouseup', endDrag);
-                            document.removeEventListener('touchmove', onDrag);
+                            document.removeEventListener('touchmove', onDrag, { passive: false });
                             document.removeEventListener('touchend', endDrag);
                         };
 
                         document.addEventListener('mousemove', onDrag);
                         document.addEventListener('mouseup', endDrag);
-                        document.addEventListener('touchmove', onDrag);
+                        document.addEventListener('touchmove', onDrag, { passive: false });
                         document.addEventListener('touchend', endDrag);
                     };
 
                     progressBar.addEventListener('mousedown', startDrag);
-                    progressBar.addEventListener('touchstart', startDrag);
+                    progressBar.addEventListener('touchstart', startDrag, { passive: true });
                 }
 
                 return section;


### PR DESCRIPTION
This commit fixes a bug where the progress bar handle would sometimes remain in its enlarged 'dragging' state after the user released it.

The drag-and-drop logic has been made more robust:
- It now checks the video's playing state before the drag begins and restores it correctly afterward.
- A `.catch()` block is added to the `video.play()` call to prevent unhandled errors from blocking the cleanup of event listeners.
- The `click` event listener was removed to prevent conflicts with the more comprehensive `mousedown`/`touchstart` drag logic.