### PR TITLE
feat: Animate sidebar and remove initial pause icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
         <template id="slide-template">
             <div class="webyx-section swiper-slide">
                 <div class="tiktok-symulacja">
-                    <video controls crossorigin playsinline muted autoplay preload="auto" poster="" class="player"></video>
+                    <video crossorigin playsinline muted autoplay preload="auto" poster="" class="player"></video>
                     <div class="pause-overlay" data-action="play-video" aria-hidden="true">
                         <svg class="pause-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
                             <path d="M8 5v14l11-7z" />

--- a/script.js
+++ b/script.js
@@ -699,6 +699,10 @@
                 const preloader = document.getElementById('preloader');
                 const showBar = () => {
                     installBar.classList.add('visible');
+                    const firstSlideSidebar = document.querySelector('.webyx-section[data-index="0"] .sidebar');
+                    if (firstSlideSidebar) {
+                        firstSlideSidebar.classList.add('visible');
+                    }
                 };
                 if (preloader && preloader.style.display !== 'none' && !preloader.classList.contains('preloader-hiding')) {
                     const observer = new MutationObserver((mutations, obs) => {

--- a/style.css
+++ b/style.css
@@ -360,13 +360,17 @@
         .tiktok-symulacja .sidebar {
             position: absolute;
             top: calc((var(--app-height) - var(--topbar-height) - var(--bottombar-height)) / 2 + var(--topbar-height));
-            right: -4px;
+            right: -80px;
             transform: translateY(-50%);
             display: flex;
             flex-direction: column;
             align-items: center;
             gap: 6px;
             z-index: 105;
+            transition: right 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+        }
+        .tiktok-symulacja .sidebar.visible {
+            right: -4px;
         }
         .tiktok-symulacja .bottombar {
             position: absolute;


### PR DESCRIPTION
This commit introduces two UI improvements based on user feedback:

1.  The sidebar on the first video now animates in from the right, simultaneously with the PWA installation banner animating in from the bottom. This creates a more coordinated and polished initial experience.

2.  The native browser `controls` attribute has been removed from the video elements. This prevents the default browser pause icon from briefly appearing and fading out when a video first loads, which was a source of visual noise. The application's custom controls remain fully functional.