### PR TITLE
fix: Ensure sidebar is visible in PWA mode and on all slides

### DIFF
--- a/script.js
+++ b/script.js
@@ -699,10 +699,7 @@
                 const preloader = document.getElementById('preloader');
                 const showBar = () => {
                     installBar.classList.add('visible');
-                    const firstSlideSidebar = document.querySelector('.webyx-section[data-index="0"] .sidebar');
-                    if (firstSlideSidebar) {
-                        firstSlideSidebar.classList.add('visible');
-                    }
+                    document.querySelectorAll('.sidebar').forEach(s => s.classList.add('visible'));
                 };
                 if (preloader && preloader.style.display !== 'none' && !preloader.classList.contains('preloader-hiding')) {
                     const observer = new MutationObserver((mutations, obs) => {
@@ -728,6 +725,7 @@
                 if (isStandalone()) {
                     updatePwaUiForInstalledState();
                     // Do not set up other install listeners if already installed.
+                    document.querySelectorAll('.sidebar').forEach(s => s.classList.add('visible'));
                     return;
                 }
 


### PR DESCRIPTION
This commit fixes a regression from a previous change where the sidebar would not appear when the application was run as an installed PWA.

The root cause was that the sidebar's visibility was tied to the appearance of the PWA install banner, which is not shown in standalone PWA mode.

The fix includes:
- In PWA mode, all sidebars are now made visible on application startup.
- In browser mode, the logic to show the sidebar along with the install banner has been corrected to apply to all slides, not just the first one. This fixes a latent bug where the sidebar would be missing on subsequent videos.