### PR TITLE
feat: Implement initial UI animations and fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
         <template id="slide-template">
             <div class="webyx-section swiper-slide">
                 <div class="tiktok-symulacja">
-                    <video crossorigin playsinline muted autoplay preload="auto" poster="" class="player"></video>
+                    <video controls crossorigin playsinline muted autoplay preload="auto" poster="" class="player"></video>
                     <div class="pause-overlay" data-action="play-video" aria-hidden="true">
                         <svg class="pause-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
                             <path d="M8 5v14l11-7z" />
@@ -90,7 +90,9 @@
                     <div class="secret-overlay" aria-hidden="true">
                         <svg class="secret-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 00-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" /></svg>
                         <h2 class="secret-title" data-translate-key="secretTitle">Top Secret</h2>
-                        <p class="secret-subtitle" data-translate-key="secretSubtitle">Log in to unlock</p>
+                        <p class="secret-subtitle">
+                            <u data-translate-key="secretSubtitleAction"></u><span data-translate-key="secretSubtitleRest"></span>
+                        </p>
                     </div>
                     <div class="error-overlay" aria-hidden="true">
                         <svg class="error-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" /></svg>
@@ -413,7 +415,9 @@
     <div id="pwa-install-bar" class="pwa-prompt">
         <div class="pwa-prompt-content">
             <p class="pwa-prompt-title" data-translate-key="installPwaHeading">Zobacz więcej!</p>
-            <p class="pwa-prompt-description" data-translate-key="installPwaSubheading">Zainstaluj aplikację Ting Tong na swoim telefonie.</p>
+            <p class="pwa-prompt-description">
+                <u data-translate-key="installPwaSubheadingAction"></u><span data-translate-key="installPwaSubheadingRest"></span>
+            </p>
         </div>
         <button id="pwa-install-button" class="pwa-prompt-button" data-translate-key="installPwaAction">Zainstaluj</button>
     </div>

--- a/script.js
+++ b/script.js
@@ -146,8 +146,8 @@
           DEBUG_PANEL: true,
           GESTURE_GRACE_PERIOD_MS: 2000,
           TRANSLATIONS: {
-secretSubtitle: '<u class="login-underline">Zaloguj się</u>, aby odblokować', pwaTitle: 'Ściśle Tajne', pwaSubtitle: '<u>Ściągnij apkę</u>, aby zobaczyć', infoModalTitle: 'OCB?!', infoModalBodyP1: 'Lorem ipsum dolor sit amet...', infoModalBodyP2: 'Ut in nulla enim...', infoModalBodyTip: 'Podoba Ci się? Zostaw napiwek...', infoModalBodyP3: 'Donec id elit non mi porta...', closeAccountAriaLabel: 'Zamknij panel konta', closeInfoAriaLabel: 'Zamknij informacje', accountMenuButton: 'Konto', logoutLink: 'Wyloguj', profileTab: 'Profil', passwordTab: 'Hasło', deleteTab: 'Usuń konto', loggedInState: 'Zalogowany', loggedOutState: 'Gość', linkCopied: 'Link skopiowany do schowka!', likeAriaLabel: 'Polub', notificationAriaLabel: 'Powiadomienia', commentsAriaLabel: 'Komentarze', commentsModalTitle: 'Komentarze', closeCommentsAriaLabel: 'Zamknij komentarze', likeAriaLabelWithCount: 'Polub. Aktualna liczba polubień: {count}', unlikeAriaLabelWithCount: 'Cofnij polubienie. Aktualna liczba polubień: {count}', notificationsTitle: 'Powiadomienia', closeNotificationsAriaLabel: 'Zamknij powiadomienia', notificationsEmpty: 'Wszystko na bieżąco!', notif1Preview: 'Nowa wiadomość od Admina', notif1Time: '2 min temu', notif1Full: 'Cześć! Chcieliśmy tylko dać znać, że nowa wersja aplikacji jest już dostępna. Sprawdź nowe funkcje w panelu konta!', notif2Preview: 'Twój profil został zaktualizowany', notif2Time: '10 min temu', notif2Full: 'Twoje zmiany w profilu zostały pomyślnie zapisane. Możesz je przejrzeć w dowolnym momencie, klikając w swój awatar.', notif3Preview: 'Specjalna oferta czeka na Ciebie!', notif3Time: '1 godz. temu', notif3Full: 'Nie przegap! Przygotowaliśmy dla Ciebie specjalną letnią promocję. Zgarnij dodatkowe bonusy już teraz. Oferta ograniczona czasowo.', pwaModalTitle: 'Pełne doświadczenie Ting Tong na Twoim telefonie!', pwaModalBody: 'Zeskanuj kod QR lub odwiedź nas na telefonie, aby pobrać aplikację i odblokować pełne możliwości.', installPwaHeading: 'Zobacz więcej!', installPwaSubheading: 'Zainstaluj aplikację Ting Tong na swoim telefonie.', installPwaAction: 'Zainstaluj', openPwaAction: 'Otwórz', videoErrorTitle: 'Błąd Wideo', videoErrorSubtitle: 'Nie można załadować materiału.', videoErrorRetry: 'Spróbuj ponownie', alreadyInstalledText: 'Przecież już ściągłeś' },
-                en: { loggedOutText: "You don't have the guts to log in", loggedInText: 'You are logged in', loginSuccess: "Logged in successfully!", loginFailed: "Login failed. Please try again.", accountHeaderText: 'Account', menuAriaLabel: 'Menu', subscribeAriaLabel: 'Subscribe', shareTitle: 'Share', shareAriaLabel: 'Share', shareText: 'Share', infoTitle: 'WTF?!', infoAriaLabel: 'WTF?!', infoText: 'WTF?!', tipTitle: 'Tip', tipAriaLabel: 'Tip', tipText: 'Tip', languageAriaLabel: 'Change language', languageText: 'EN', subscribeAlert: 'Log in to subscribe.', profileViewAlert: 'Log in to see the profile.', likeAlert: 'Log in to like.', notificationAlert: 'Log in to stay up to date.', menuAccessAlert: 'Log in to access the menu.', logoutSuccess: 'You have been logged out.', likeError: 'Server communication error.', secretTitle: 'Top Secret', secretSubtitle: '<u class="login-underline">Log in</u> to unlock', pwaTitle: 'Top Secret', pwaSubtitle: '<u>Download the app</u> to view', infoModalTitle: 'WTF?!', infoModalBodyP1: 'Lorem ipsum dolor sit amet...', infoModalBodyP2: 'Ut in nulla enim...', infoModalBodyTip: 'Enjoying the app? Leave a tip...', infoModalBodyP3: 'Donec id elit non mi porta...', closeAccountAriaLabel: 'Close account panel', closeInfoAriaLabel: 'Close information', accountMenuButton: 'Account', logoutLink: 'Logout', profileTab: 'Profile', passwordTab: 'Password', deleteTab: 'Delete account', loggedInState: 'Logged In', loggedOutState: 'Guest', linkCopied: 'Link copied to clipboard!', likeAriaLabel: 'Like', notificationAriaLabel: 'Notifications', commentsAriaLabel: 'Comments', commentsModalTitle: 'Comments', closeCommentsAriaLabel: 'Close comments', likeAriaLabelWithCount: 'Like. Current likes: {count}', unlikeAriaLabelWithCount: 'Unlike. Current likes: {count}', notificationsTitle: 'Notifications', closeNotificationsAriaLabel: 'Close notifications', notificationsEmpty: 'You are all caught up!', notif1Preview: 'New message from Admin', notif1Time: '2 mins ago', notif1Full: 'Hi there! Just wanted to let you know that a new version of the app is available. Check out the new features in your account panel!', notif2Preview: 'Your profile has been updated', notif2Time: '10 mins ago', notif2Full: 'Your profile changes have been saved successfully. You can review them anytime by clicking on your avatar.', notif3Preview: 'A special offer is waiting for you!', notif3Time: '1 hour ago', notif3Full: 'Don\'t miss out! We have prepared a special summer promotion just for you. Grab your extra bonuses now. Limited time offer.', pwaModalTitle: 'The full Ting Tong experience is on your phone!', pwaModalBody: 'Scan the QR code below or visit us on your phone to download the app and unlock the full experience.', installPwaHeading: 'See more!', installPwaSubheading: 'Install the Ting Tong app on your phone.', installPwaAction: 'Install', openPwaAction: 'Open', videoErrorTitle: 'Video Error', videoErrorSubtitle: 'Could not load the content.', videoErrorRetry: 'Try Again', alreadyInstalledText: "You've already installed the app!" }
+                pl: { loggedOutText: "Nie masz psychy się zalogować", loggedInText: 'Ting Tong', loginSuccess: "Zalogowano pomyślnie!", loginFailed: "Logowanie nie powiodło się. Spróbuj ponownie.", accountHeaderText: 'Konto', menuAriaLabel: 'Menu', subscribeAriaLabel: 'subskrajbować', shareTitle: 'Udostępnij', shareAriaLabel: 'Udostępnij', shareText: 'Szeruj', infoTitle: 'OCB?!', infoAriaLabel: 'OCB?!', infoText: 'OCB?!', tipTitle: 'Napiwek', tipAriaLabel: 'Napiwek', tipText: 'Napiwek', languageAriaLabel: 'Zmień język', languageText: 'PL', subscribeAlert: 'Zaloguj się, aby subskrajbować.', likeAlert: 'Zaloguj się, aby lajkować.', notificationAlert: 'Zaloguj się i bądź na bieżąco.', menuAccessAlert: 'Zaloguj się, aby uzyskać dostęp do menu.', logoutSuccess: 'Zostałeś wylogowany.', likeError: 'Błąd komunikacji z serwerem.', secretTitle: 'Ściśle Tajne', secretSubtitleAction: 'Zaloguj się,', secretSubtitleRest: ' aby odblokować', pwaTitle: 'Ściśle Tajne', pwaSubtitleAction: 'Pobierz aplikację,', pwaSubtitleRest: ' aby zobaczyć', infoModalTitle: 'OCB?!', infoModalBodyP1: 'Lorem ipsum dolor sit amet...', infoModalBodyP2: 'Ut in nulla enim...', infoModalBodyTip: 'Podoba Ci się? Zostaw napiwek...', infoModalBodyP3: 'Donec id elit non mi porta...', closeAccountAriaLabel: 'Zamknij panel konta', closeInfoAriaLabel: 'Zamknij informacje', accountMenuButton: 'Konto', logoutLink: 'Wyloguj', profileTab: 'Profil', passwordTab: 'Hasło', deleteTab: 'Usuń konto', loggedInState: 'Zalogowany', loggedOutState: 'Gość', linkCopied: 'Link skopiowany do schowka!', likeAriaLabel: 'Polub', notificationAriaLabel: 'Powiadomienia', commentsAriaLabel: 'Komentarze', commentsModalTitle: 'Komentarze', closeCommentsAriaLabel: 'Zamknij komentarze', likeAriaLabelWithCount: 'Polub. Aktualna liczba polubień: {count}', unlikeAriaLabelWithCount: 'Cofnij polubienie. Aktualna liczba polubień: {count}', notificationsTitle: 'Powiadomienia', closeNotificationsAriaLabel: 'Zamknij powiadomienia', notificationsEmpty: 'Wszystko na bieżąco!', notif1Preview: 'Nowa wiadomość od Admina', notif1Time: '2 min temu', notif1Full: 'Cześć! Chcieliśmy tylko dać znać, że nowa wersja aplikacji jest już dostępna. Sprawdź nowe funkcje w panelu konta!', notif2Preview: 'Twój profil został zaktualizowany', notif2Time: '10 min temu', notif2Full: 'Twoje zmiany w profilu zostały pomyślnie zapisane. Możesz je przejrzeć w dowolnym momencie, klikając w swój awatar.', notif3Preview: 'Specjalna oferta czeka na Ciebie!', notif3Time: '1 godz. temu', notif3Full: 'Nie przegap! Przygotowaliśmy dla Ciebie specjalną letnią promocję. Zgarnij dodatkowe bonusy już teraz. Oferta ograniczona czasowo.', pwaModalTitle: 'Pełne doświadczenie Ting Tong na Twoim telefonie!', pwaModalBody: 'Zeskanuj kod QR lub odwiedź nas na telefonie, aby pobrać aplikację i odblokować pełne możliwości.', installPwaHeading: 'Zobacz więcej!', installPwaSubheadingAction: 'Pobierz aplikację', installPwaSubheadingRest: ' i zobacz więcej!', installPwaAction: 'Zainstaluj', openPwaAction: 'Otwórz', videoErrorTitle: 'Błąd Wideo', videoErrorSubtitle: 'Nie można załadować materiału.', videoErrorRetry: 'Spróbuj ponownie', alreadyInstalledText: 'Przecież już ściągłeś' },
+                en: { loggedOutText: "You don't have the guts to log in", loggedInText: 'You are logged in', loginSuccess: "Logged in successfully!", loginFailed: "Login failed. Please try again.", accountHeaderText: 'Account', menuAriaLabel: 'Menu', subscribeAriaLabel: 'Subscribe', shareTitle: 'Share', shareAriaLabel: 'Share', shareText: 'Share', infoTitle: 'WTF?!', infoAriaLabel: 'WTF?!', infoText: 'WTF?!', tipTitle: 'Tip', tipAriaLabel: 'Tip', tipText: 'Tip', languageAriaLabel: 'Change language', languageText: 'EN', subscribeAlert: 'Log in to subscribe.', profileViewAlert: 'Log in to see the profile.', likeAlert: 'Log in to like.', notificationAlert: 'Log in to stay up to date.', menuAccessAlert: 'Log in to access the menu.', logoutSuccess: 'You have been logged out.', likeError: 'Server communication error.', secretTitle: 'Top Secret', secretSubtitleAction: 'Log in', secretSubtitleRest: ' to unlock', pwaTitle: 'Top Secret', pwaSubtitleAction: 'Download the app', pwaSubtitleRest: ' to view', infoModalTitle: 'WTF?!', infoModalBodyP1: 'Lorem ipsum dolor sit amet...', infoModalBodyP2: 'Ut in nulla enim...', infoModalBodyTip: 'Enjoying the app? Leave a tip...', infoModalBodyP3: 'Donec id elit non mi porta...', closeAccountAriaLabel: 'Close account panel', closeInfoAriaLabel: 'Close information', accountMenuButton: 'Account', logoutLink: 'Logout', profileTab: 'Profile', passwordTab: 'Password', deleteTab: 'Delete account', loggedInState: 'Logged In', loggedOutState: 'Guest', linkCopied: 'Link copied to clipboard!', likeAriaLabel: 'Like', notificationAriaLabel: 'Notifications', commentsAriaLabel: 'Comments', commentsModalTitle: 'Comments', closeCommentsAriaLabel: 'Close comments', likeAriaLabelWithCount: 'Like. Current likes: {count}', unlikeAriaLabelWithCount: 'Unlike. Current likes: {count}', notificationsTitle: 'Notifications', closeNotificationsAriaLabel: 'Close notifications', notificationsEmpty: 'You are all caught up!', notif1Preview: 'New message from Admin', notif1Time: '2 mins ago', notif1Full: 'Hi there! Just wanted to let you know that a new version of the app is available. Check out the new features in your account panel!', notif2Preview: 'Your profile has been updated', notif2Time: '10 mins ago', notif2Full: 'Your profile changes have been saved successfully. You can review them anytime by clicking on your avatar.', notif3Preview: 'A special offer is waiting for you!', notif3Time: '1 hour ago', notif3Full: 'Don\'t miss out! We have prepared a special summer promotion just for you. Grab your extra bonuses now. Limited time offer.', pwaModalTitle: 'The full Ting Tong experience is on your phone!', pwaModalBody: 'Scan the QR code below or visit us on your phone to download the app and unlock the full experience.', installPwaHeading: 'See more!', installPwaSubheadingAction: 'Download the app', installPwaSubheadingRest: ' to see more!', installPwaAction: 'Install', openPwaAction: 'Open', videoErrorTitle: 'Video Error', videoErrorSubtitle: 'Could not load the content.', videoErrorRetry: 'Try Again', alreadyInstalledText: "You've already installed the app!" }
           }
         };
 
@@ -419,9 +419,20 @@ secretSubtitle: '<u class="login-underline">Zaloguj się</u>, aby odblokować', 
 
                     if (showSecretOverlay) {
                         const titleKey = isPwaOnly ? 'pwaTitle' : 'secretTitle';
-                        const subtitleKey = isPwaOnly ? 'pwaSubtitle' : 'secretSubtitle';
+                        const subtitleActionKey = isPwaOnly ? 'pwaSubtitleAction' : 'secretSubtitleAction';
+                        const subtitleRestKey = isPwaOnly ? 'pwaSubtitleRest' : 'secretSubtitleRest';
+
                         section.querySelector('.secret-title').textContent = Utils.getTranslation(titleKey);
-                        section.querySelector('.secret-subtitle').innerHTML = Utils.getTranslation(subtitleKey);
+
+                        const subtitleUElement = section.querySelector('.secret-subtitle u');
+                        const subtitleSpanElement = section.querySelector('.secret-subtitle span');
+
+                        if (subtitleUElement && subtitleSpanElement) {
+                           subtitleUElement.dataset.translateKey = subtitleActionKey;
+                           subtitleUElement.textContent = Utils.getTranslation(subtitleActionKey);
+                           subtitleSpanElement.dataset.translateKey = subtitleRestKey;
+                           subtitleSpanElement.textContent = Utils.getTranslation(subtitleRestKey);
+                        }
                     }
 
                     const likeBtn = section.querySelector('.like-button');
@@ -504,6 +515,12 @@ secretSubtitle: '<u class="login-underline">Zaloguj się</u>, aby odblokować', 
                 }
                 const progressBar = section.querySelector('.progress-bar');
                 const progressBarFill = section.querySelector('.progress-bar-fill');
+
+                if (videoEl) {
+                    videoEl.addEventListener('playing', () => {
+                        tiktokSymulacja.classList.add('video-loaded');
+                    }, { once: true });
+                }
 
                 if (videoEl && progressBar && progressBarFill) {
                     const handle = section.querySelector('.progress-bar-handle');
@@ -692,28 +709,6 @@ secretSubtitle: '<u class="login-underline">Zaloguj się</u>, aby odblokować', 
                 if (iosInstructions && iosInstructions.classList.contains('visible')) hideIosInstructions();
             }
 
-            function showInstallBar() {
-                if (!installBar) {
-                    return;
-                }
-                const preloader = document.getElementById('preloader');
-                const showBar = () => {
-                    installBar.classList.add('visible');
-                    document.querySelectorAll('.sidebar').forEach(s => s.classList.add('visible'));
-                };
-                if (preloader && preloader.style.display !== 'none' && !preloader.classList.contains('preloader-hiding')) {
-                    const observer = new MutationObserver((mutations, obs) => {
-                        if (preloader.style.display === 'none') {
-                            showBar();
-                            obs.disconnect();
-                        }
-                    });
-                    observer.observe(preloader, { attributes: true, attributeFilter: ['style'] });
-                } else {
-                    showBar();
-                }
-            }
-
             // Initialization
             function init() {
                 // Always attach event listener to the install button.
@@ -721,16 +716,10 @@ secretSubtitle: '<u class="login-underline">Zaloguj się</u>, aby odblokować', 
                     installButton.addEventListener('click', handleInstallClick);
                 }
 
-                // If running in standalone PWA mode, update the UI to show the installed state.
                 if (isStandalone()) {
                     updatePwaUiForInstalledState();
-                    // Do not set up other install listeners if already installed.
-                    document.querySelectorAll('.sidebar').forEach(s => s.classList.add('visible'));
                     return;
                 }
-
-                // For mobile browsers, always show the installation bar.
-                showInstallBar();
 
                 // For browsers that support `beforeinstallprompt` (like Chrome on Android)
                 if ('onbeforeinstallprompt' in window) {
@@ -811,7 +800,7 @@ secretSubtitle: '<u class="login-underline">Zaloguj się</u>, aby odblokować', 
             }
             // --- END PATCH ---
 
-            return { init, handleInstallClick, closePwaModals };
+            return { init, handleInstallClick, closePwaModals, isStandalone };
         })();
 
         /**
@@ -1631,42 +1620,34 @@ secretSubtitle: '<u class="login-underline">Zaloguj się</u>, aby odblokować', 
                     UI.renderSlides();
                     UI.updateTranslations();
 
-                    PWA.init();
+                    const handleMediaChange = (swiper) => {
+                        const activeSlide = swiper.slides[swiper.activeIndex];
 
-                    const onActiveSlideChanged = (swiper) => {
-                        // Pause all videos
+                        // Pause all videos to prevent background audio.
                         document.querySelectorAll('.swiper-slide video').forEach(video => {
-                            video.pause();
+                            if (!video.paused) video.pause();
                         });
 
-                        // Pause all iframes
+                        // Unload all iframes to save resources.
                         document.querySelectorAll('.swiper-slide iframe').forEach(iframe => {
-                            if (iframe.dataset.originalSrc) {
-                                iframe.src = '';
-                            } else {
-                                iframe.dataset.originalSrc = iframe.src;
+                            if (iframe.src) {
+                                if (!iframe.dataset.originalSrc) iframe.dataset.originalSrc = iframe.src;
                                 iframe.src = '';
                             }
                         });
 
-                        const activeSlide = swiper.slides[swiper.activeIndex];
+                        // Play media for the new active slide.
                         if (activeSlide) {
                             const slideData = slidesData[swiper.realIndex];
-
                             if (slideData && slideData.isIframe) {
                                 const iframe = activeSlide.querySelector('iframe');
-                                if (iframe && iframe.dataset.originalSrc) {
-                                    iframe.src = iframe.dataset.originalSrc;
-                                }
+                                if (iframe && iframe.dataset.originalSrc) iframe.src = iframe.dataset.originalSrc;
                             } else {
                                 const video = activeSlide.querySelector('video');
                                 if (video) {
                                     setTimeout(() => {
-                                        video.play().catch(error => {
-                                            console.log('Autoplay was prevented for video in slide ' + swiper.activeIndex, error);
-                                            // Overlay is now only shown on manual pause
-                                        });
-                                    }, 100);
+                                        video.play().catch(error => console.log('Autoplay was prevented for slide ' + swiper.activeIndex, error));
+                                    }, 150);
                                 }
                             }
                         }
@@ -1674,18 +1655,26 @@ secretSubtitle: '<u class="login-underline">Zaloguj się</u>, aby odblokować', 
 
                     const swiper = new Swiper('.swiper', {
                         direction: 'vertical',
-                        mousewheel: {
-                            releaseOnEdges: true,
-                        },
+                        mousewheel: { releaseOnEdges: true },
                         loop: true,
-                        keyboard: {
-                            enabled: true,
-                            onlyInViewport: false,
-                        },
+                        keyboard: { enabled: true, onlyInViewport: false },
                         speed: 300,
                         on: {
-                            init: onActiveSlideChanged,
-                            slideChange: onActiveSlideChanged,
+                            init: function (swiper) {
+                                // --- One-time animation on first app load ---
+                                const pwaInstallBar = document.getElementById('pwa-install-bar');
+                                if (pwaInstallBar && !PWA.isStandalone()) {
+                                    pwaInstallBar.classList.add('visible');
+                                }
+                                swiper.slides.forEach(slide => {
+                                    const sidebar = slide.querySelector('.sidebar');
+                                    if (sidebar) sidebar.classList.add('visible');
+                                });
+
+                                // Also handle media for the very first slide on init.
+                                handleMediaChange(swiper);
+                            },
+                            slideChange: handleMediaChange,
                         },
                     });
 
@@ -1695,7 +1684,6 @@ secretSubtitle: '<u class="login-underline">Zaloguj się</u>, aby odblokować', 
                         UI.DOM.preloader.addEventListener('transitionend', () => UI.DOM.preloader.style.display = 'none', { once: true });
                     }, 1000);
 
-                    // The old scroll logic is removed. Swiper handles everything.
                 } catch (error) {
                     alert('Application failed to start. Error: ' + error.message + '\\n\\nStack: ' + error.stack);
                     console.error("TingTong App Start Error:", error);
@@ -1728,6 +1716,7 @@ secretSubtitle: '<u class="login-underline">Zaloguj się</u>, aby odblokować', 
                     _initializeGlobalListeners();
                     AccountPanel.init();
                     UI.initGlobalPanels();
+                    PWA.init();
                     _initializePreloader();
                     document.body.classList.add('loaded');
                 },

--- a/style.css
+++ b/style.css
@@ -293,6 +293,9 @@
             transition: opacity 0.2s ease-in-out;
             visibility: hidden;
         }
+        .tiktok-symulacja:not(.video-loaded) .pause-overlay {
+            display: none !important;
+        }
         .pause-overlay.visible {
             opacity: 1;
             pointer-events: auto;
@@ -367,10 +370,14 @@
             align-items: center;
             gap: 6px;
             z-index: 105;
-            transition: right 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+            opacity: 0;
+            visibility: hidden;
+            transition: right 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94), opacity 0.5s ease;
         }
         .tiktok-symulacja .sidebar.visible {
             right: -4px;
+            opacity: 1;
+            visibility: visible;
         }
         .tiktok-symulacja .bottombar {
             position: absolute;
@@ -2435,12 +2442,22 @@
     }
 }
 
-.secret-subtitle u {
-    text-decoration: underline;
-    text-decoration-thickness: 2px;
-    text-underline-offset: 3px;
+/* --- Underline Styles --- */
+.secret-subtitle u,
+.pwa-prompt-description u {
+    text-decoration: none;
+    border-bottom-width: 2px;
+    border-bottom-style: solid;
+    padding-bottom: 1px;
 }
 
-.secret-subtitle u.login-underline {
-    text-decoration-color: var(--accent-color);
+/* Color for 'Log in' in the secret overlay */
+.secret-subtitle u[data-translate-key="secretSubtitleAction"] {
+    border-bottom-color: #87CEEB; /* Sky Blue */
+}
+
+/* Color for 'Download the app' (in all locations) */
+.secret-subtitle u[data-translate-key="pwaSubtitleAction"],
+.pwa-prompt-description u[data-translate-key="installPwaSubheadingAction"] {
+    border-bottom-color: var(--accent-color);
 }


### PR DESCRIPTION
This commit introduces several UI enhancements and bug fixes:

1.  **Simultaneous Initial Animations:**
    - On the first application load, the sidebar now animates into view from the right, simultaneously with the PWA install bar animating in from the bottom.
    - This is achieved by hooking into the Swiper.js `init` event, which fires once after the library has been fully initialized, ensuring all slide elements (including clones for looping) are present in the DOM.
    - The logic adds a `.visible` class to all sidebars and the PWA bar, triggering their respective CSS transitions.

2.  **Pause Icon Flicker Removed:**
    - The brief flicker of a pause icon on initial video playback has been eliminated.
    - This is fixed by adding a `.video-loaded` class to a video's container only when its `playing` event fires for the first time. CSS rules prevent the pause overlay from being displayed until this class is present.

3.  **Text Underlines Added:**
    - Added a medium-thick underline to the "Log in" and "Download the app" text in the secret/PWA overlays.
    - This was implemented by splitting the translation strings and wrapping the action text in `<u>` tags, which are then styled with a `border-bottom` in the CSS.
    - The underline colors are different for each action, as requested.