### PR TITLE
Fix UI timing for PWA banner and sidebar animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -1662,10 +1662,6 @@
                         on: {
                             init: function (swiper) {
                                 // --- One-time animation on first app load ---
-                                const pwaInstallBar = document.getElementById('pwa-install-bar');
-                                if (pwaInstallBar && !PWA.isStandalone()) {
-                                    pwaInstallBar.classList.add('visible');
-                                }
                                 swiper.slides.forEach(slide => {
                                     const sidebar = slide.querySelector('.sidebar');
                                     if (sidebar) sidebar.classList.add('visible');
@@ -1681,6 +1677,10 @@
                     setTimeout(() => {
                         UI.DOM.preloader.classList.add('preloader-hiding');
                         UI.DOM.container.classList.add('ready');
+                        const pwaInstallBar = document.getElementById('pwa-install-bar');
+                        if (pwaInstallBar && !PWA.isStandalone()) {
+                            pwaInstallBar.classList.add('visible');
+                        }
                         UI.DOM.preloader.addEventListener('transitionend', () => UI.DOM.preloader.style.display = 'none', { once: true });
                     }, 1000);
 

--- a/style.css
+++ b/style.css
@@ -363,8 +363,8 @@
         .tiktok-symulacja .sidebar {
             position: absolute;
             top: calc((var(--app-height) - var(--topbar-height) - var(--bottombar-height)) / 2 + var(--topbar-height));
-            right: -80px;
-            transform: translateY(-50%);
+    right: -4px;
+    transform: translateY(-50%) translateX(100%);
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -372,10 +372,10 @@
             z-index: 105;
             opacity: 0;
             visibility: hidden;
-            transition: right 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94), opacity 0.5s ease;
+    transition: transform 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94), opacity 0.5s ease;
         }
         .tiktok-symulacja .sidebar.visible {
-            right: -4px;
+    transform: translateY(-50%) translateX(0);
             opacity: 1;
             visibility: visible;
         }


### PR DESCRIPTION
- Delays the appearance of the PWA installation bar until the main feed content is visible, preventing it from showing too early during the preloader phase.
- Adjusts the sidebar animation to slide in smoothly from the right using `transform`, creating a cleaner "emerging" effect as requested.