### PR TITLE
chore: Slow down UI animations

### DIFF
--- a/style.css
+++ b/style.css
@@ -371,7 +371,7 @@
             gap: 6px;
             z-index: 105;
             visibility: hidden;
-    transition: transform 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    transition: transform 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94);
         }
         .tiktok-symulacja .sidebar.visible {
     transform: translateY(-50%) translateX(0);
@@ -1899,7 +1899,7 @@
 
     /* PATCH: Animate from bottom */
     transform: translateY(100%);
-    transition: transform 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    transition: transform 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94);
     visibility: hidden;
     height: var(--bottombar-height);
 }


### PR DESCRIPTION
Based on user feedback, the transition duration for the sidebar and the PWA install prompt animations has been increased from 0.5s to 0.8s to make them slower and less abrupt.