### PR TITLE
fix: Prevent momentary pause icon on scroll

### DIFF
--- a/script.js
+++ b/script.js
@@ -1648,7 +1648,12 @@
                                 const video = activeSlide.querySelector('video');
                                 if (video) {
                                     setTimeout(() => {
-                                        video.play().catch(error => console.log('Autoplay was prevented for slide ' + swiper.activeIndex, error));
+                                        video.play().then(() => {
+                                            const pauseOverlay = activeSlide.querySelector('.pause-overlay');
+                                            if (pauseOverlay) {
+                                                pauseOverlay.classList.remove('visible');
+                                            }
+                                        }).catch(error => console.log('Autoplay was prevented for slide ' + swiper.activeIndex, error));
                                     }, 150);
                                 }
                             }


### PR DESCRIPTION
This commit fixes an issue where the pause/play icon would flash briefly when scrolling back to a video that was previously paused.

The `handleMediaChange` function is updated to explicitly hide the pause overlay when a video begins playing successfully. This is achieved by adding a `.then()` callback to the `video.play()` promise, which ensures the overlay is hidden once playback starts.