### PR TITLE
style: Update progress bar color and z-index

### DIFF
--- a/style.css
+++ b/style.css
@@ -141,6 +141,7 @@
         :root {
             --app-height: 100vh;
             --accent-color: #ff0055;
+            --progress-bar-color: #42A5F5;
             --main-ui-bg-color: #696969;
             --transition-speed: 0.4s;
             --transition-timing: cubic-bezier(0.25, 0.46, 0.45, 0.94);
@@ -401,6 +402,7 @@
     -webkit-tap-highlight-color: transparent;
     display: flex;
     align-items: center;
+    z-index: 10003;
 }
 
 .progress-bar::before {
@@ -422,7 +424,7 @@
     transform: translateY(-50%);
     width: 0%;
     height: 4px;
-    background-color: var(--accent-color);
+    background-color: var(--progress-bar-color);
     border-radius: 2px;
     transition: height 0.2s ease-in-out;
     pointer-events: none;


### PR DESCRIPTION
Based on user feedback, the following changes were made to the progress bar:
- A new CSS variable `--progress-bar-color` has been created and set to a light blue color to differentiate it from the PWA install prompt.
- The `z-index` of the progress bar has been increased to ensure it appears on top of the PWA install prompt.