### PR TITLE
feat: Update progress bar and installation prompt styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -141,7 +141,7 @@
         :root {
             --app-height: 100vh;
             --accent-color: #ff0055;
-            --progress-bar-color: #42A5F5;
+            --progress-bar-color: #4CAF50;
             --main-ui-bg-color: #696969;
             --transition-speed: 0.4s;
             --transition-timing: cubic-bezier(0.25, 0.46, 0.45, 0.94);
@@ -402,7 +402,7 @@
     -webkit-tap-highlight-color: transparent;
     display: flex;
     align-items: center;
-    z-index: 10003;
+    z-index: 10004;
 }
 
 .progress-bar::before {
@@ -2459,5 +2459,6 @@
 /* Color for 'Download the app' (in all locations) */
 .secret-subtitle u[data-translate-key="pwaSubtitleAction"],
 .pwa-prompt-description u[data-translate-key="installPwaSubheadingAction"] {
-    border-bottom-color: var(--accent-color);
+    border-bottom: none !important;
+    text-decoration: none !important;
 }


### PR DESCRIPTION
This commit addresses three UI improvements based on user feedback:

1.  The progress bar color has been changed to a more optimistic green (#4CAF50) to make it stand out.
2.  The z-index of the progress bar has been increased to ensure it and its handle (the dot) render on top of the PWA installation prompt.
3.  The underline has been removed from the text in the PWA installation prompt for a cleaner look.