### PR TITLE
fix: Update progress bar and installation prompt styles based on feed…

### DIFF
--- a/style.css
+++ b/style.css
@@ -402,7 +402,7 @@
     -webkit-tap-highlight-color: transparent;
     display: flex;
     align-items: center;
-    z-index: 10004;
+    z-index: 10010;
 }
 
 .progress-bar::before {
@@ -413,7 +413,7 @@
     transform: translateY(-50%);
     width: 100%;
     height: 4px;
-    background-color: rgba(255, 255, 255, 0.25);
+    background-color: rgba(76, 175, 80, 0.3);
     transition: height 0.2s ease-in-out;
 }
 


### PR DESCRIPTION
…back

This commit addresses user feedback on the previous changes:

1.  The progress bar track (the unfilled part) is now colored with a muted version of the optimistic green, making it distinct from other UI elements as requested.
2.  The z-index of the progress bar has been further increased to 10010 to definitively solve the layering issue and ensure it always appears on top of the PWA installation prompt and other modals.