### PR TITLE
feat: Update video progress bar color and fix PWA banner overlap

### DIFF
--- a/script.js
+++ b/script.js
@@ -738,6 +738,10 @@
                         installPromptEvent = null;
                         isAppInstalled = true; // Set state
                         updatePwaUiForInstalledState();
+                        const pwaInstallBar = document.getElementById('pwa-install-bar');
+                        if (pwaInstallBar) pwaInstallBar.classList.remove('visible');
+                        const appFrame = document.getElementById('app-frame');
+                        if (appFrame) appFrame.classList.remove('app-frame--pwa-visible');
                     });
                 }
 
@@ -775,32 +779,6 @@
                     UI.showAlert(Utils.getTranslation('alreadyInstalledText'));
                 }
             }
-
-            // --- PATCH: Dynamically adjust progress bar for PWA prompt ---
-            const pwaBar = document.getElementById('pwa-install-bar');
-            const root = document.documentElement;
-
-            if (pwaBar) {
-                const pwaObserver = new MutationObserver(() => {
-                    requestAnimationFrame(() => {
-                        if (pwaBar.classList.contains('visible')) {
-                            // When PWA bar is visible, position the progress bar above it.
-                            root.style.setProperty('--progress-bar-bottom-offset', `${pwaBar.offsetHeight}px`);
-                        } else {
-                            // When PWA bar is hidden, revert to the default position above the main bottom bar.
-                            root.style.removeProperty('--progress-bar-bottom-offset');
-                        }
-                    });
-                });
-
-                pwaObserver.observe(pwaBar, { attributes: true, attributeFilter: ['class'] });
-
-                // Initial check in case the bar is already visible on load
-                if (pwaBar.classList.contains('visible')) {
-                     root.style.setProperty('--progress-bar-bottom-offset', `${pwaBar.offsetHeight}px`);
-                }
-            }
-            // --- END PATCH ---
 
             return { init, handleInstallClick, closePwaModals, isStandalone };
         })();
@@ -1681,8 +1659,10 @@
                         UI.DOM.preloader.classList.add('preloader-hiding');
                         UI.DOM.container.classList.add('ready');
                         const pwaInstallBar = document.getElementById('pwa-install-bar');
+                        const appFrame = document.getElementById('app-frame');
                         if (pwaInstallBar && !PWA.isStandalone()) {
                             pwaInstallBar.classList.add('visible');
+                            if (appFrame) appFrame.classList.add('app-frame--pwa-visible');
                         }
                         document.querySelectorAll('.sidebar').forEach(sidebar => {
                             sidebar.classList.add('visible');

--- a/style.css
+++ b/style.css
@@ -141,7 +141,7 @@
         :root {
             --app-height: 100vh;
             --accent-color: #ff0055;
-            --progress-bar-color: #4CAF50;
+            --progress-bar-color: var(--accent-color);
             --main-ui-bg-color: #696969;
             --transition-speed: 0.4s;
             --transition-timing: cubic-bezier(0.25, 0.46, 0.45, 0.94);
@@ -413,7 +413,7 @@
     transform: translateY(-50%);
     width: 100%;
     height: 4px;
-    background-color: rgba(76, 175, 80, 0.3);
+    background-color: rgba(255, 0, 85, 0.3);
     transition: height 0.2s ease-in-out;
 }
 
@@ -1875,6 +1875,20 @@
             outline: 2px solid white;
             outline-offset: 2px;
         }
+
+#app-frame {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    transition: all 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+#app-frame.app-frame--pwa-visible {
+    height: calc(100% - var(--bottombar-height));
+}
+
 
 /* PWA Prompt Styles from Reference */
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
- Changed the video progress bar color to pink to match the site's accent color.
- Updated the progress bar track to a lighter, transparent pink for a consistent look.
- Refactored the layout to prevent the PWA installation banner from overlapping with the app's bottom bar.
- The main app frame now resizes when the PWA banner is visible, ensuring all UI elements remain accessible.