### PR TITLE
feat: Adjust bottom bar padding for PWA install bar

### DIFF
--- a/style.css
+++ b/style.css
@@ -392,6 +392,11 @@
             z-index: 10006;
             padding-bottom: calc(10px + var(--safe-area-bottom));
         }
+
+/* Dodaj tę regułę, aby dostosować dolny pasek, gdy widoczny jest pasek instalacji PWA */
+.app-frame--pwa-visible .bottombar {
+    padding-top: 30px;
+}
 .progress-bar {
     position: absolute;
     top: 0;


### PR DESCRIPTION
Adds a specific CSS rule to increase the top padding of the `.bottombar` when the PWA installation prompt is visible.

This prevents the PWA bar from overlapping and hiding the video progress bar, ensuring all UI elements are accessible as intended.