### PR TITLE
Remove controls attribute from video tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
         <template id="slide-template">
             <div class="webyx-section swiper-slide">
                 <div class="tiktok-symulacja">
-                    <video controls crossorigin playsinline muted autoplay preload="auto" poster="" class="player"></video>
+                    <video crossorigin playsinline muted autoplay preload="auto" poster="" class="player"></video>
                     <div class="pause-overlay" data-action="play-video" aria-hidden="true">
                         <svg class="pause-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
                             <path d="M8 5v14l11-7z" />


### PR DESCRIPTION
Removes the 'controls' attribute from the video tag in index.html to hide the default browser video controls. This is done to allow for custom video controls and to prevent the pause icon from appearing on initially paused videos in the feed.