### PR TITLE
Fix: Correct video icon display and progress bar positioning

### DIFF
--- a/script.js
+++ b/script.js
@@ -575,17 +575,18 @@
 
                 if (tiktokSymulacja && videoEl && pauseOverlay) {
                     tiktokSymulacja.addEventListener('click', (e) => {
-                        if (e.target.closest('.sidebar, .bottombar')) {
+                        // Upewnij się, że kliknięcie nie pochodzi z paska bocznego lub dolnego
+                        if (e.target.closest('.sidebar, .bottombar, .secret-overlay')) {
                             return;
                         }
                         if (videoEl.paused) {
-                            videoEl.play();
+                            // Wznów odtwarzanie i ukryj nakładkę
+                            videoEl.play().catch(error => console.log('Błąd odtwarzania:', error));
                             pauseOverlay.classList.remove('visible');
                         } else {
+                            // Spauzuj wideo i pokaż nakładkę z ikoną play
                             videoEl.pause();
-                            if (tiktokSymulacja.classList.contains('video-loaded')) {
-                                pauseOverlay.classList.add('visible');
-                            }
+                            pauseOverlay.classList.add('visible');
                         }
                     });
                 }
@@ -2011,13 +2012,13 @@
                             } else {
                                 const video = activeSlide.querySelector('video');
                                 if (video) {
+                                    // Nowe wideo nie powinno mieć widocznej nakładki pauzy
+                                    const pauseOverlay = activeSlide.querySelector('.pause-overlay');
+                                    if (pauseOverlay) {
+                                        pauseOverlay.classList.remove('visible');
+                                    }
                                     setTimeout(() => {
-                                        video.play().then(() => {
-                                            const pauseOverlay = activeSlide.querySelector('.pause-overlay');
-                                            if (pauseOverlay) {
-                                                pauseOverlay.classList.remove('visible');
-                                            }
-                                        }).catch(error => console.log('Autoplay was prevented for slide ' + swiper.activeIndex, error));
+                                        video.play().catch(error => console.log('Autoplay was prevented for slide ' + swiper.activeIndex, error));
                                     }, 150);
                                 }
                             }

--- a/style.css
+++ b/style.css
@@ -287,7 +287,7 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            background-color: rgba(0, 0, 0, 0.3);
+            background-color: transparent; /* Zmień kolor na przeźroczysty */
             z-index: 101;
             opacity: 0;
             pointer-events: none;
@@ -2809,4 +2809,8 @@
 .pwa-prompt-description u[data-translate-key="installPwaSubheadingAction"] {
     border-bottom: none !important;
     text-decoration: none !important;
+}
+
+.app-frame--pwa-visible .progress-bar {
+    top: -30px;
 }


### PR DESCRIPTION
This commit addresses two UI issues:

1.  The video play icon is now handled correctly. It is hidden by default on new videos and only appears when a user manually pauses the video. The semi-transparent background on the pause overlay has also been removed.

2.  The video progress bar is no longer obscured by the PWA installation bar. A CSS rule has been added to adjust its position upwards when the PWA bar is visible.