### PR TITLE
feat: Make overlay links interactive and fix comment prompt style

### DIFF
--- a/script.js
+++ b/script.js
@@ -498,6 +498,9 @@
                         const subtitleSpanElement = section.querySelector('.secret-subtitle span');
 
                         if (subtitleUElement && subtitleSpanElement) {
+                           // The data-action attribute is used by the global mainClickHandler
+                           // to trigger the correct action when this element is clicked.
+                           subtitleUElement.dataset.action = isPwaOnly ? 'install-pwa' : 'toggle-login-panel';
                            subtitleUElement.dataset.translateKey = subtitleActionKey;
                            subtitleUElement.textContent = Utils.getTranslation(subtitleActionKey);
                            subtitleSpanElement.dataset.translateKey = subtitleRestKey;

--- a/style.css
+++ b/style.css
@@ -1326,12 +1326,12 @@
         .login-to-comment-prompt {
             text-align: center;
             padding: 20px;
-            background-color: #F0F2F5;
+            background-color: #18191A;
         }
         .login-to-comment-prompt p {
             margin: 0;
             font-size: 15px;
-            color: #65676B;
+            color: #E4E6EB;
         }
         .login-to-comment-prompt a {
             color: var(--accent-color);
@@ -2842,6 +2842,7 @@
     border-bottom-width: 2px;
     border-bottom-style: solid;
     padding-bottom: 1px;
+    cursor: pointer;
 }
 
 /* Color for 'Log in' and 'Download' in the secret overlay */


### PR DESCRIPTION
This commit implements two main changes based on user feedback:

1.  The "log in" and "install app" links within the secret/PWA overlays are now functional. This is achieved by dynamically adding `data-action` attributes to the elements, which are then handled by the existing global click handler. A `cursor: pointer` style has also been added to improve UX.

2.  The styling of the "login to comment" prompt in the comments modal has been updated to match the application's dark theme. The background is now dark and the text is light, creating a more cohesive look.