### PR TITLE
Fix: Adjust progress bar position and update sort labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,10 +165,10 @@
                 <h2 id="commentsTitle" data-translate-key="commentsModalTitle">Komentarze</h2>
                 <div class="comment-sort-options">
                     <div class="sort-dropdown">
-                        <button class="sort-trigger">Sortuj według: <span class="current-sort">Najnowsze</span> ▼</button>
+                        <button class="sort-trigger">Sortuj według: <span class="current-sort">fresz</span> ▼</button>
                         <div class="sort-options">
-                            <button class="sort-option" data-sort="newest">Najnowsze</button>
-                            <button class="sort-option" data-sort="popular">Najpopularniejsze</button>
+                            <button class="sort-option" data-sort="newest">fresz</button>
+                            <button class="sort-option" data-sort="popular">best</button>
                         </div>
                     </div>
                 </div>

--- a/style.css
+++ b/style.css
@@ -395,7 +395,6 @@
 
 /* Dodaj tę regułę, aby dostosować dolny pasek, gdy widoczny jest pasek instalacji PWA */
 .app-frame--pwa-visible .bottombar {
-    padding-top: 30px;
 }
 .progress-bar {
     position: absolute;
@@ -2858,5 +2857,6 @@
 }
 
 .app-frame--pwa-visible .progress-bar {
-    top: -30px;
+    top: auto;
+    bottom: 100%;
 }


### PR DESCRIPTION
This commit addresses several UI issues based on user feedback.

- The video progress bar is repositioned to sit correctly at the top of the PWA installation prompt when it is visible on the web. The CSS was changed to use `bottom: 100%` for more robust positioning, resolving the issue where it appeared too high or was obscured.
- The comment sorting labels have been updated to 'fresz' (for newest) and 'best' (for most popular) as per the user's clarified request.