### PR TITLE
Fix: Adjust comment section UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,10 +165,10 @@
                 <h2 id="commentsTitle" data-translate-key="commentsModalTitle">Komentarze</h2>
                 <div class="comment-sort-options">
                     <div class="sort-dropdown">
-                        <button class="sort-trigger">Sortuj według: <span class="current-sort">fresz</span> ▼</button>
+                        <button class="sort-trigger">Sortuj według: <span class="current-sort">Fresz</span> ▼</button>
                         <div class="sort-options">
-                            <button class="sort-option" data-sort="newest">fresz</button>
-                            <button class="sort-option" data-sort="popular">best</button>
+                            <button class="sort-option" data-sort="newest">Fresz</button>
+                            <button class="sort-option" data-sort="popular">Best</button>
                         </div>
                     </div>
                 </div>

--- a/script.js
+++ b/script.js
@@ -1346,6 +1346,9 @@
                             break;
                         case 'toggle-login-panel':
                             if (!State.get('isUserLoggedIn')) {
+                                if (UI.DOM.commentsModal.classList.contains('visible')) {
+                                    UI.closeModal(UI.DOM.commentsModal);
+                                }
                                 if (loginPanel) loginPanel.classList.toggle('active');
                                 if (topbar) topbar.classList.toggle('login-panel-active');
                             }

--- a/style.css
+++ b/style.css
@@ -1323,9 +1323,11 @@
         }
 
         .login-to-comment-prompt {
-            text-align: center;
-            padding: 20px;
+            align-items: center;
             background-color: #18191A;
+            display: flex;
+            justify-content: center;
+            padding: 8px 12px calc(8px + var(--safe-area-bottom));
         }
         .login-to-comment-prompt p {
             margin: 0;


### PR DESCRIPTION
This commit addresses three UI issues in the comment section:
1. The "log in to comment" bar now has the same height as the logged-in user's comment bar.
2. The "fresz" and "best" sort options are now capitalized ("Fresz" and "Best").
3. Clicking the "log in" button in the comments modal now closes the modal and opens the login panel.