### PR TITLE
Refine comment modal layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,7 +162,6 @@
     <div id="commentsModal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="commentsTitle" aria-hidden="true">
         <div class="modal-content" tabindex="-1">
             <div class="modal-header">
-                <h2 id="commentsTitle" data-translate-key="commentsModalTitle">Komentarze</h2>
                 <div class="comment-sort-options">
                     <div class="sort-dropdown">
                         <button class="sort-trigger">Sortuj według: <span class="current-sort">Fresz</span> ▼</button>

--- a/style.css
+++ b/style.css
@@ -949,14 +949,6 @@
             height: 40px; /* Reduce height */
             border-bottom: 1px solid #333; /* Add a separator */
         }
-        #commentsModal h2 {
-            margin: 0;
-            font-size: 15px; /* Slightly smaller font */
-            font-weight: 600;
-            color: #E4E6EB; /* Light title for dark theme */
-            text-align: center;
-            flex-grow: 1; /* Allow title to take up space */
-        }
         #commentsModal .modal-close-btn {
             color: #B0B3B8;
             opacity: 1;
@@ -1328,6 +1320,7 @@
             display: flex;
             justify-content: center;
             padding: 8px 12px calc(8px + var(--safe-area-bottom));
+    text-align: center;
         }
         .login-to-comment-prompt p {
             margin: 0;


### PR DESCRIPTION
- Remove the "Komentarze" header from the comment modal.
- Reposition the "Sortuj według" (Sort by) dropdown to the left.
- Center the "Zaloguj aby komentować" (Log in to comment) prompt.