### PR TITLE
Fix: Comments modal not opening after UI changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,7 +159,7 @@
             </div>
         </div>
     </div>
-    <div id="commentsModal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="commentsTitle" aria-hidden="true">
+    <div id="commentsModal" class="modal-overlay" role="dialog" aria-modal="true" aria-label="Komentarze" aria-hidden="true">
         <div class="modal-content" tabindex="-1">
             <div class="modal-header">
                 <div class="comment-sort-options">

--- a/script.js
+++ b/script.js
@@ -1288,8 +1288,6 @@
                             if (slideId) {
                                 const slideData = slidesData.find(s => s.id === slideId);
                                 if (slideData) {
-                                    const commentsTitle = UI.DOM.commentsModal.querySelector('#commentsTitle');
-                                    commentsTitle.textContent = `Komentarze (${slideData.initialComments})`;
                                 }
 
                                 // Show a loading state


### PR DESCRIPTION
This commit fixes a regression introduced in the previous commit where the comments modal would not open.

The issue was caused by JavaScript code trying to access the `#commentsTitle` element, which had been removed. This caused a runtime error, preventing the modal from opening.

The fix involves:
- Removing the JavaScript code that referenced the deleted element.
- Replacing the broken `aria-labelledby` attribute with a proper `aria-label` on the modal `div` to maintain accessibility.