### PR TITLE
feat: Update profile tab colors for better visibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -2671,11 +2671,11 @@
     text-align: center;
     cursor: pointer;
     position: relative;
-    color: rgba(255, 255, 255, 0.6);
+    color: rgba(255, 255, 255, 0.8);
 }
 
 .profile-tabs .tab.active {
-    color: #fff;
+    color: var(--accent-color);
 }
 
 .profile-tabs .tab.active::after {
@@ -2685,7 +2685,7 @@
     left: 0;
     width: 100%;
     height: 2px;
-    background-color: #fff;
+    background-color: var(--accent-color);
 }
 
 .profile-tabs .tab svg {


### PR DESCRIPTION
The colors of the tabs in the creator's profile have been updated to improve visibility and align with the website's style.

- The active tab color and underline now use the `--accent-color` variable.
- The inactive tab color has been made more opaque to stand out against the background.