### PR TITLE
feat: Make login panel full-width on desktop

### DIFF
--- a/style.css
+++ b/style.css
@@ -2871,7 +2871,7 @@
         aspect-ratio: 9 / 16;
         position: relative;
     }
-    .topbar {
+    .topbar, .login-panel {
         position: fixed;
         width: 100%;
         max-width: 100%;


### PR DESCRIPTION
This change updates the CSS to make the login panel full-width and sticky on wider screens, matching the behavior of the top bar.