### PR TITLE
Refactor: Remove closeAccountModal from AccountPanel

### DIFF
--- a/script.js
+++ b/script.js
@@ -1331,7 +1331,7 @@
                             }
                             break;
                         case 'close-account-modal':
-                            AccountPanel.closeAccountModal();
+                            UI.closeModal(UI.DOM.accountModal);
                             break;
                         case 'logout':
                             e.preventDefault();
@@ -1631,34 +1631,6 @@
                 loadInitialProfileData(); // Fetch live data when opening
             }
 
-            function closeAccountModal() {
-                const modal = document.getElementById('accountModal');
-                const modalContent = modal.querySelector('.account-modal-content');
-
-                // Do nothing if the modal is not visible or is already closing.
-                if (!modal.classList.contains('visible') || modal.classList.contains('is-hiding')) {
-                    return;
-                }
-
-                const onTransitionEnd = (event) => {
-                    // Ensure we're reacting to the end of the transform on the correct element.
-                    if (event.target === modalContent && event.propertyName === 'transform') {
-                        modal.classList.remove('visible');
-                        modal.classList.remove('is-hiding');
-                        // Clean up the event listener.
-                        modalContent.removeEventListener('transitionend', onTransitionEnd);
-                    }
-                };
-
-                modalContent.addEventListener('transitionend', onTransitionEnd);
-
-                // Add the is-hiding class to trigger the closing animation.
-                // The .visible class remains for now, so the overlay is still visible during the animation.
-                modal.classList.add('is-hiding');
-
-                // Restore body scrolling immediately.
-                document.body.style.overflow = '';
-            }
 
             // Tab switching
             function initializeModal() {
@@ -1948,7 +1920,7 @@
             function showSuccess(elementId, message) { hideAllMessages(); const el = document.getElementById(elementId); el.textContent = message; el.style.display = 'block'; requestAnimationFrame(() => el.classList.add('show')); setTimeout(() => { el.classList.remove('show'); setTimeout(() => el.style.display = 'none', 300); }, 3000); }
             function showError(elementId, message) { hideAllMessages(); const el = document.getElementById(elementId); el.textContent = message; el.style.display = 'block'; requestAnimationFrame(() => el.classList.add('show')); setTimeout(() => { el.classList.remove('show'); setTimeout(() => el.style.display = 'none', 300); }, 4000); }
 
-            return { init, openAccountModal, closeAccountModal };
+            return { init, openAccountModal };
         })();
 
 


### PR DESCRIPTION
The closeAccountModal function in the AccountPanel module has been removed.

The 'close-account-modal' case in the Handlers.mainClickHandler function has been changed to use UI.closeModal(UI.DOM.accountModal) instead.