### PR TITLE
Fix: Slow down modal closing animation

### DIFF
--- a/style.css
+++ b/style.css
@@ -2510,6 +2510,7 @@
 
 #tiktok-profile-modal.is-hiding .tiktok-profile-content {
     transform: translateX(100%);
+	transition-duration: 0.8s;
 }
 
 .tiktok-profile-header {


### PR DESCRIPTION
Increased the transition duration for the creator profile modal's closing animation to 0.8s.

This change directly addresses user feedback that the closing animation was still too fast. The opening animation remains at 0.4s, while the closing animation is now explicitly slower.