### PR TITLE
Fix: Revert modal animation to ensure consistent speed

### DIFF
--- a/style.css
+++ b/style.css
@@ -2510,7 +2510,6 @@
 
 #tiktok-profile-modal.is-hiding .tiktok-profile-content {
     transform: translateX(100%);
-	transition-duration: 0.8s;
 }
 
 .tiktok-profile-header {


### PR DESCRIPTION
Reverted the creator profile modal's closing animation to be governed by the base transition rule.

Previous attempts to explicitly set the closing speed led to unexpected behavior. This change simplifies the CSS, ensuring both the opening and closing animations use the exact same `transition` property (`transform 0.4s ease-in-out`), which should guarantee they run at the same speed as requested.