### PR TITLE
Fix: Set explicit transition for modal hiding animation

### DIFF
--- a/style.css
+++ b/style.css
@@ -2510,6 +2510,7 @@
 
 #tiktok-profile-modal.is-hiding .tiktok-profile-content {
     transform: translateX(100%);
+    transition: transform 0.4s ease-in-out;
 }
 
 .tiktok-profile-header {


### PR DESCRIPTION
The creator profile modal was hiding much faster than it was appearing. This was because the CSS rule for the hiding state (`.is-hiding`) did not have an explicit `transition` property, which could lead to inconsistent behavior in some browsers.

This change adds an explicit `transition: transform 0.4s ease-in-out;` to the `#tiktok-profile-modal.is-hiding .tiktok-profile-content` rule in `style.css`.

This ensures the hiding animation has the same duration and timing function as the showing animation, providing a consistent user experience.