### PR TITLE
fix: standardize modal closing animations for all modals

### DIFF
--- a/script.js
+++ b/script.js
@@ -411,7 +411,11 @@
                 if ((modal.id === 'tiktok-profile-modal' || modal.id === 'commentsModal' || modal.id === 'accountModal') && modalContent) {
                     if (modal.classList.contains('is-hiding')) return;
 
-                    const onTransitionEnd = () => {
+                    let animationFinished = false;
+                    const cleanup = () => {
+                        if (animationFinished) return;
+                        animationFinished = true;
+
                         modal.classList.remove('visible', 'is-hiding');
                         if (modal._focusTrapDispose) {
                             modal._focusTrapDispose();
@@ -421,7 +425,10 @@
                         State.get('lastFocusedElement')?.focus();
                     };
 
-                    modalContent.addEventListener('transitionend', onTransitionEnd, { once: true });
+                    modalContent.addEventListener('transitionend', cleanup, { once: true });
+                    // Fallback timeout in case the transitionend event doesn't fire
+                    setTimeout(cleanup, 500);
+
                     modal.classList.add('is-hiding');
                     modal.setAttribute('aria-hidden', 'true');
 

--- a/style.css
+++ b/style.css
@@ -2510,7 +2510,6 @@
 
 #tiktok-profile-modal.is-hiding .tiktok-profile-content {
     transform: translateX(100%);
-    transition: transform 0.4s ease-in-out;
 }
 
 .tiktok-profile-header {


### PR DESCRIPTION
This commit ensures that both the creator profile modal and the user profile edit modal have a consistent slide-out animation that mirrors their slide-in animation.

The `UI.closeModal` function in `script.js` has been made more robust with a `setTimeout` fallback to handle cases where the `transitionend` event may not fire. This ensures a consistent and reliable closing animation for all modals.

Additionally, a redundant `transition` property was removed from the `#tiktok-profile-modal.is-hiding .tiktok-profile-content` rule in `style.css` to prevent conflicts and align it with the animation patterns of other modals.