### PR TITLE
Ustawia jajeco.jpg jako ikonę aplikacji, splash i preloader

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,18 +17,18 @@
     <!-- PATCH: iOS PWA cosmetics -->
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-    <link rel="apple-touch-icon" href="polutek.png">
+    <link rel="apple-touch-icon" href="jajeco.jpg">
     <!-- PATCH: TODO - Add iOS splash screens for different devices -->
-    <link href="polutek.png" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
-    <link href="polutek.png" media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
-    <link href="polutek.png" media="(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3)" rel="apple-touch-startup-image" />
-    <link href="polutek.png" media="(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3)" rel="apple-touch-startup-image" />
-    <link href="polutek.png" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
-    <link href="polutek.png" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3)" rel="apple-touch-startup-image" />
-    <link href="polutek.png" media="(device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
-    <link href="polutek.png" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
-    <link href="polutek.png" media="(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
-    <link href="polutek.png" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
+    <link href="jajeco.jpg" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
+    <link href="jajeco.jpg" media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
+    <link href="jajeco.jpg" media="(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3)" rel="apple-touch-startup-image" />
+    <link href="jajeco.jpg" media="(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3)" rel="apple-touch-startup-image" />
+    <link href="jajeco.jpg" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
+    <link href="jajeco.jpg" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3)" rel="apple-touch-startup-image" />
+    <link href="jajeco.jpg" media="(device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
+    <link href="jajeco.jpg" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
+    <link href="jajeco.jpg" media="(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
+    <link href="jajeco.jpg" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
 
     <!-- Networking hints -->
     <link rel="preconnect" href="https://pawelperfect.pl" crossorigin>
@@ -45,7 +45,7 @@
 <body>
     <div id="preloader">
         <div class="preloader-icon-container">
-            <img src="polutek.png" alt="Ting Tong Logo" class="splash-icon">
+            <img src="jajeco.jpg" alt="Ting Tong Logo" class="splash-icon">
         </div>
         <div class="preloader-content-container">
             <div class="language-selection">

--- a/manifest.json
+++ b/manifest.json
@@ -8,14 +8,14 @@
   "description": "Ting Tong — pionowy feed wideo z prefetchingiem i trybem HLS/CDN-ready.",
   "icons": [
     {
-      "src": "polutek.png",
+      "src": "jajeco.jpg",
       "sizes": "192x192",
-      "type": "image/png"
+      "type": "image/jpeg"
     },
     {
-      "src": "polutek.png",
+      "src": "jajeco.jpg",
       "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/jpeg"
     }
   ],
   "related_applications": [{


### PR DESCRIPTION
Zgodnie z poleceniem, wszystkie odwołania do 'polutek.png' zostały zaktualizowane na 'jajeco.jpg' w plikach manifest.json i index.html.

Zmiany obejmują:
- Zaktualizowanie ikon w manifest.json.
- Zmianę typu obrazu w manifest.json na image/jpeg.
- Zaktualizowanie apple-touch-icon w index.html.
- Zaktualizowanie wszystkich apple-touch-startup-image w index.html.
- Zaktualizowanie obrazu w preloaderze w index.html.