### PR TITLE
Ustawia jajeco.jpg jako ikonę aplikacji, splash i preloader

### DIFF
--- a/style.css
+++ b/style.css
@@ -18,17 +18,15 @@
         }
         .preloader-icon-container {
             position: absolute;
-            top: 50%;
-            left: 50%;
-            transform: translate(-50%, -50%);
-            width: 192px;
-            height: 192px;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
         }
         .splash-icon {
             width: 100%;
             height: 100%;
             object-fit: contain;
-            animation: pulse-glow 2.5s infinite ease-in-out;
         }
         @keyframes pulse-glow {
             0% {
@@ -46,7 +44,7 @@
         }
         .preloader-content-container {
             position: absolute;
-            top: calc(50% + 96px); /* 96px is half of the icon's 192px height */
+            top: 0;
             bottom: 0;
             left: 0;
             width: 100%;


### PR DESCRIPTION
Zgodnie z poleceniem, wszystkie odwołania do 'polutek.png' zostały zaktualizowane na 'jajeco.jpg' w plikach manifest.json i index.html.

Zmiany obejmują:
- Zaktualizowanie ikon w manifest.json.
- Zmianę typu obrazu w manifest.json na image/jpeg.
- Zaktualizowanie apple-touch-icon w index.html.
- Zaktualizowanie wszystkich apple-touch-startup-image w index.html.
- Zaktualizowanie obrazu w preloaderze w index.html.
- Poprawiono style CSS, aby preloader zajmował cały ekran, zapewniając spójny wygląd z natywnym ekranem powitalnym.