### PR TITLE
feat: Restore splash and preloader appearance

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <link rel="apple-touch-icon" href="jajeco.jpg">
     <!-- PATCH: TODO - Add iOS splash screens for different devices -->
+    <!--
     <link href="jajeco.jpg" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
     <link href="jajeco.jpg" media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
     <link href="jajeco.jpg" media="(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3)" rel="apple-touch-startup-image" />
@@ -29,6 +30,7 @@
     <link href="jajeco.jpg" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
     <link href="jajeco.jpg" media="(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
     <link href="jajeco.jpg" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
+    -->
 
     <!-- Networking hints -->
     <link rel="preconnect" href="https://pawelperfect.pl" crossorigin>

--- a/style.css
+++ b/style.css
@@ -18,15 +18,17 @@
         }
         .preloader-icon-container {
             position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            width: 192px;
+            height: 192px;
         }
         .splash-icon {
             width: 100%;
             height: 100%;
             object-fit: contain;
+            animation: pulse-glow 2.5s infinite ease-in-out;
         }
         @keyframes pulse-glow {
             0% {
@@ -44,7 +46,7 @@
         }
         .preloader-content-container {
             position: absolute;
-            top: 0;
+            top: calc(50% + 96px); /* 96px is half of the icon's 192px height */
             bottom: 0;
             left: 0;
             width: 100%;


### PR DESCRIPTION
This commit reverts the styles for the preloader and splash screen to match the design from the `feat/mobile-keyboard-ux-enhancement` branch.

Changes include:
- Updating `style.css` to center the preloader icon and add a pulsing animation.
- Adjusting the layout of the preloader content container.
- Commenting out the `apple-touch-startup-image` links in `index.html` to align with the reference branch configuration.