### PR TITLE
feat: Convert static project to a WordPress theme and add deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy WordPress Theme via FTP
+
+on:
+  push:
+    branches:
+      - main # lub 'master', w zależności od nazwy Twojej głównej gałęzi
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: FTP Deploy
+      uses: SamKirkland/FTP-Deploy-Action@4.3.3
+      with:
+        server: ${{ secrets.FTP_SERVER }}
+        username: ${{ secrets.FTP_USERNAME }}
+        password: ${{ secrets.FTP_PASSWORD }}
+        local-dir: ./ting-tong-theme/
+        server-dir: /public_html/autoinstalator/wordpresspluslscache2/wp-content/themes/ting-tong-theme/
+        protocol: ftp
+        port: 21
+        timeout: 30000
+        log-level: "verbose"
+        exclude: |
+          **/.git*
+          **/.git*/**
+          **/node_modules/**
+          .github/**


### PR DESCRIPTION
This commit transforms the existing static HTML, CSS, and JavaScript project into a standard WordPress theme and adds a GitHub Action for automated FTP deployment.

Key Changes:
- A new `ting-tong-theme` directory has been created to house all theme files.
- The original `index.html` has been split into `header.php`, `footer.php`, and a main template `index.php`.
- A `functions.php` file has been added to enqueue all styles and scripts correctly using WordPress functions.
- Data is passed from PHP to JavaScript using `wp_localize_script`.
- The `style.css` file has been updated with the required WordPress theme header.
- A GitHub Action workflow file (`.github/workflows/deploy.yml`) has been added to automate the deployment of the theme to an FTP server on every push to the main branch.