### PR TITLE
Fix(deploy): Update FTP deployment path in workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
         username: ${{ secrets.FTP_USERNAME }}
         password: ${{ secrets.FTP_PASSWORD }}
         local-dir: ./ting-tong-theme/
-        server-dir: /public_html/autoinstalator/wordpresspluslscache2/wp-content/themes/ting-tong-theme/
+        server-dir: /autoinstalator/wordpresspluslscache2/wp-content/themes/ting-tong-theme/
         protocol: ftp
         port: 21
         timeout: 30000


### PR DESCRIPTION
The `server-dir` for the FTP deployment in the GitHub Actions workflow has been updated to point to the correct directory on the server. The leading `/public_html` has been removed, and the path has been corrected to be absolute to prevent potential deployment issues.