### PR TITLE
Dodaje funkcję, która wyłącza buforowanie strony po stronie przegląda…

### DIFF
--- a/ting-tong-theme/functions.php
+++ b/ting-tong-theme/functions.php
@@ -586,6 +586,19 @@ add_action('wp_ajax_tt_account_delete', function () {
 // =========================================================================
 
 /**
+ * Wyłącza cachowanie strony poprzez wysyłanie odpowiednich nagłówków.
+ */
+function tt_disable_caching() {
+    if (!is_user_logged_in()) {
+        header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
+        header("Cache-Control: post-check=0, pre-check=0", false);
+        header("Pragma: no-cache");
+        header("Expires: Sat, 26 Jul 1997 05:00:00 GMT");
+    }
+}
+add_action('init', 'tt_disable_caching');
+
+/**
  * Shortcode [tt_login_form] generujący formularz dla AJAX.
  */
 add_shortcode( 'tt_login_form', function() {


### PR DESCRIPTION
…rki dla niezalogowanych użytkowników.

Zmiana została wprowadzona w pliku `functions.php` poprzez dodanie funkcji `tt_disable_caching` podpiętej do akcji `init`. Funkcja ta wysyła odpowiednie nagłówki HTTP (`Cache-Control`, `Pragma`, `Expires`), aby zapobiec zapisywaniu strony w pamięci podręcznej.