### PR TITLE
Fix: Zapewnienie poprawnej instalacji PWA poprzez dodanie obsługi zda…

### DIFF
--- a/ting-tong-theme/sw.js
+++ b/ting-tong-theme/sw.js
@@ -1,3 +1,10 @@
+self.addEventListener('install', (event) => {
+  // Ten event listener jest niezbędny, aby przeglądarka uznała
+  // aplikację za instalowalną PWA. `self.skipWaiting()` zapewnia,
+  // że nowy service worker aktywuje się od razu.
+  self.skipWaiting();
+});
+
 const OFFLINE_PAGE_HTML = `
 <!DOCTYPE html>
 <html lang="pl">


### PR DESCRIPTION
…rzenia 'install'

Ten commit naprawia błąd, który uniemożliwiał instalację aplikacji PWA, mimo że monit o instalację był wyświetlany. Problem polegał na braku wymaganego event listenera dla zdarzenia `install` w pliku service workera (`sw.js`).

Dodano teraz minimalny, ale niezbędny, `install` event listener, który wywołuje `self.skipWaiting()`. Dzięki temu przeglądarka poprawnie rozpoznaje aplikację jako w pełni instalowalną i może zakończyć proces instalacji.

Ta zmiana jest kontynuacją poprzednich prac nad logiką PWA, które scentralizowały pokazywanie i ukrywanie paska instalacyjnego. Połączone zmiany zapewniają, że aplikacja jest nie tylko instalowalna, ale także poprawnie reaguje na swój stan (przeglądarka vs. PWA).