### PR TITLE
feat: Disable all caching and fix form layout

### DIFF
--- a/ting-tong-theme/functions.php
+++ b/ting-tong-theme/functions.php
@@ -175,10 +175,10 @@ function tt_get_slides_data() {
  */
 function tt_enqueue_and_localize_scripts() {
 	wp_enqueue_style( 'swiper-css', 'https://cdn.jsdelivr.net/npm/swiper@12.0.2/swiper-bundle.min.css', [], '12.0.2' );
-	wp_enqueue_style( 'tingtong-style', get_stylesheet_uri(), [ 'swiper-css' ], '1.0.1' );
+	wp_enqueue_style( 'tingtong-style', get_stylesheet_uri(), [ 'swiper-css' ], null );
 
 	wp_enqueue_script( 'swiper-js', 'https://cdn.jsdelivr.net/npm/swiper@12.0.2/swiper-bundle.min.js', [], '12.0.2', true );
-	wp_enqueue_script( 'tingtong-script', get_template_directory_uri() . '/script.js', [ 'jquery', 'swiper-js' ], '1.0.1', true );
+	wp_enqueue_script( 'tingtong-script', get_template_directory_uri() . '/script.js', [ 'jquery', 'swiper-js' ], null, true );
 
 	wp_localize_script(
 		'tingtong-script',
@@ -645,15 +645,14 @@ add_action('wp_ajax_tt_account_delete', function () {
 // =========================================================================
 
 /**
- * Wyłącza cachowanie strony poprzez wysyłanie odpowiednich nagłówków.
+ * Wyłącza cachowanie strony poprzez wysyłanie odpowiednich nagłówków DLA WSZYSTKICH.
  */
 function tt_disable_caching() {
-    if (!is_user_logged_in()) {
-        header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
-        header("Cache-Control: post-check=0, pre-check=0", false);
-        header("Pragma: no-cache");
-        header("Expires: Sat, 26 Jul 1997 05:00:00 GMT");
-    }
+    // WYMUSZ POBIERANIE ŚWIEŻEJ WERSJI STRONY
+    header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
+    header("Cache-Control: post-check=0, pre-check=0", false);
+    header("Pragma: no-cache");
+    header("Expires: Sat, 26 Jul 1997 05:00:00 GMT");
 }
 add_action('init', 'tt_disable_caching');
 

--- a/ting-tong-theme/header.php
+++ b/ting-tong-theme/header.php
@@ -11,7 +11,7 @@
 
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-    <link rel="apple-touch-icon" href="<?php echo get_template_directory_uri(); ?>/jajeco.jpg">
+    <!-- <link rel="apple-touch-icon" href="<?php echo get_template_directory_uri(); ?>/jajeco.jpg"> -->
 
     <link rel="preconnect" href="https://pawelperfect.pl" crossorigin>
     <link rel="preconnect" href="https://i.pravatar.cc" crossorigin>

--- a/ting-tong-theme/script.js
+++ b/ting-tong-theme/script.js
@@ -1,3 +1,13 @@
+// DEZAKTYWACJA SERVICE WORKER (USUWANIE CACHE PWA)
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.getRegistrations().then(function(registrations) {
+    for(let registration of registrations) {
+      registration.unregister();
+      console.log('Service Worker unregistered');
+    }
+  });
+}
+
 (() => {
   /* ============================
    * 1) CDN helper + preconnect

--- a/ting-tong-theme/style.css
+++ b/ting-tong-theme/style.css
@@ -2756,6 +2756,17 @@ body,
   bottom: 100%;
 }
 
+.form-row {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.form-row .form-group {
+  flex: 1;
+  min-width: calc(50% - 8px);
+}
+
 @media (min-aspect-ratio: 9/16) {
   html,
   body {


### PR DESCRIPTION
This commit implements two main changes based on user requests:

1.  **Disable Caching Mechanisms:**
    - Modifies `functions.php` to send `Cache-Control: no-store, no-cache...` headers for all users, not just logged-out ones, by removing the `!is_user_logged_in()` condition.
    - Sets the version parameter to `null` in `wp_enqueue_style` and `wp_enqueue_script` to prevent WordPress from adding theme-specific version query strings to assets.
    - Adds a script to `script.js` to unregister any active Service Workers on page load, effectively disabling PWA client-side caching.
    - Comments out the `apple-touch-icon` link in `header.php` to remove PWA-related elements.

2.  **Correct Personal Data Form Layout:**
    - Adds CSS rules to `style.css` to properly align the fields in the personal data form. The `.form-row` container is now a flex container, ensuring its child `.form-group` elements are evenly distributed.