### PR TITLE
Fix: Ukryj pasek PWA w trybie standalone i popraw układ formularza

### DIFF
--- a/ting-tong-theme/script.js
+++ b/ting-tong-theme/script.js
@@ -1763,17 +1763,6 @@ document.addEventListener("DOMContentLoaded", () => {
         installButton.addEventListener("click", handleInstallClick);
       }
 
-      if (isStandalone()) {
-        // If running as a PWA, hide the install bar immediately by adding the
-        // .force-hide class, which has `display: none !important;`.
-        const installBar = document.getElementById("pwa-install-bar");
-        if (installBar) {
-          installBar.classList.add("force-hide");
-        }
-        updatePwaUiForInstalledState();
-        return;
-      }
-
       // For browsers that support `beforeinstallprompt` (like Chrome on Android)
       if ("onbeforeinstallprompt" in window) {
         window.addEventListener("beforeinstallprompt", (e) => {
@@ -3400,15 +3389,17 @@ document.addEventListener("DOMContentLoaded", () => {
           // [Poprawiony fragment dla paska PWA]
           // Sprawdza, czy pasek istnieje i CZY JESTEŚMY W TRYBIE PRZEGLĄDARKOWYM.
           if (pwaInstallBar && !PWA.isStandalone()) {
-              // Tryb przeglądarkowy: Pokaż pasek i dostosuj wysokość app-frame
-              pwaInstallBar.classList.add("visible");
-              if (appFrame) appFrame.classList.add("app-frame--pwa-visible");
+            // Tryb przeglądarkowy: Pokaż pasek i dostosuj wysokość app-frame
+            pwaInstallBar.classList.add("visible");
+            if (appFrame) appFrame.classList.add("app-frame--pwa-visible");
           } else {
-              // Tryb PWA lub brak paska: Ukryj pasek i upewnij się, że app-frame ma pełną wysokość
-              if (pwaInstallBar) {
-                  pwaInstallBar.classList.remove("visible"); // Upewnienie się, że jest ukryty
-              }
-              if (appFrame) appFrame.classList.remove("app-frame--pwa-visible");
+            // Tryb PWA lub brak paska: Jawnie ukryj pasek za pomocą dedykowanej klasy.
+            if (pwaInstallBar) {
+              pwaInstallBar.classList.add("force-hide");
+            }
+            if (appFrame) {
+              appFrame.classList.remove("app-frame--pwa-visible");
+            }
           }
           document.querySelectorAll(".sidebar").forEach((sidebar) => {
             sidebar.classList.add("visible");

--- a/ting-tong-theme/style.css
+++ b/ting-tong-theme/style.css
@@ -2794,17 +2794,17 @@ body,
 /* --- FIX: Poprawki układu formularza --- */
 #profile-tab .form-group {
     display: flex;
-    flex-direction: row; /* Etykieta i input obok siebie */
-    align-items: center;
-    gap: 10px;
+    flex-direction: column; /* Ustawia etykietę i input w kolumnie */
+    align-items: stretch; /* Rozciąga elementy do pełnej szerokości */
+    gap: 8px; /* Odstęp między etykietą a inputem */
 }
 
 #profile-tab .form-label {
-    flex: 0 0 80px; /* Stała szerokość dla etykiety, np. 80px */
-    text-align: right;
-    margin-bottom: 0; /* Usuń margines dolny, bo jest już w .form-group */
+    flex: none; /* Usuwa właściwości flex */
+    text-align: left; /* Wyrównuje tekst etykiety do lewej */
+    margin-bottom: 0; /* Zeruje margines, bo gap jest w .form-group */
 }
 
 #profile-tab .form-input {
-    flex: 1; /* Input zajmie resztę dostępnego miejsca */
+    flex: none; /* Usuwa właściwości flex */
 }


### PR DESCRIPTION
Wprowadzono dwie poprawki zgodnie z prośbą użytkownika:

- W `script.js` dodano logikę, która sprawdza, czy aplikacja działa w trybie PWA (`PWA.isStandalone()`). Jeśli tak, do paska instalacji dodawana jest klasa `force-hide`, która go ukrywa. Usunięto również zduplikowany i nieefektywny kod, który próbował zarządzać widocznością tego paska.

- W `style.css` zmodyfikowano reguły dla `#profile-tab .form-group`, zmieniając `flex-direction` na `column`. Zapewnia to, że etykiety pól formularza danych osobowych wyświetlają się nad polami, a nie obok nich, co poprawia czytelność i wygląd.