### PR TITLE
Fix: Poprawia układ formularza w panelu konta

### DIFF
--- a/jules-scratch/memory.txt
+++ b/jules-scratch/memory.txt
@@ -1,0 +1,1 @@
+In `ting-tong-theme/style.css`, the `.form-row` class within the `#profile-tab` should have `flex-direction: column` to ensure form elements like first name and last name are stacked vertically instead of appearing in a single row.

--- a/ting-tong-theme/style.css
+++ b/ting-tong-theme/style.css
@@ -2762,6 +2762,11 @@ body,
   flex-wrap: wrap;
 }
 
+#profile-tab .form-row {
+  flex-direction: column;
+  gap: 0;
+}
+
 .form-row .form-group {
   flex: 1;
   min-width: calc(50% - 8px);


### PR DESCRIPTION
Zmienia styl CSS dla formularza danych osobowych w panelu konta. Ustawia `flex-direction: column` dla kontenera `.form-row` wewnątrz `#profile-tab`, co powoduje, że pola (np. Imię i Nazwisko) układają się pionowo, jedno pod drugim, zamiast w jednym wierszu.

Poprawia to czytelność i jest zgodne z prośbą użytkownika.