### PR TITLE
Fix: Poprawia układ i odstępy w formularzu konta

### DIFF
--- a/jules-scratch/memory.txt
+++ b/jules-scratch/memory.txt
@@ -1,1 +1,0 @@
-In `ting-tong-theme/style.css`, the `.form-row` class within the `#profile-tab` should have `flex-direction: column` to ensure form elements like first name and last name are stacked vertically instead of appearing in a single row.

--- a/ting-tong-theme/style.css
+++ b/ting-tong-theme/style.css
@@ -2762,11 +2762,6 @@ body,
   flex-wrap: wrap;
 }
 
-#profile-tab .form-row {
-  flex-direction: column;
-  gap: 0;
-}
-
 .form-row .form-group {
   flex: 1;
   min-width: calc(50% - 8px);
@@ -2797,19 +2792,17 @@ body,
 }
 
 /* --- FIX: Poprawki układu formularza --- */
+#profile-tab #profileForm,
+#profile-tab .form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 16px; /* Spójny odstęp między wszystkimi polami */
+}
+
 #profile-tab .form-group {
-    display: flex;
-    flex-direction: column; /* Ustawia etykietę i input w kolumnie */
-    align-items: stretch; /* Rozciąga elementy do pełnej szerokości */
-    gap: 8px; /* Odstęp między etykietą a inputem */
+    margin-bottom: 0; /* Usuwamy stary margines, polegamy na 'gap' */
 }
 
 #profile-tab .form-label {
-    flex: none; /* Usuwa właściwości flex */
-    text-align: left; /* Wyrównuje tekst etykiety do lewej */
-    margin-bottom: 0; /* Zeruje margines, bo gap jest w .form-group */
-}
-
-#profile-tab .form-input {
-    flex: none; /* Usuwa właściwości flex */
+    margin-bottom: 8px; /* Dodajemy mały odstęp między etykietą a polem input */
 }


### PR DESCRIPTION
Modyfikuje `style.css`, aby poprawić wygląd formularza danych osobowych w panelu konta.

- Zastosowano `display: flex` z `flex-direction: column` oraz `gap` dla kontenera formularza (`#profileForm`) i `.form-row`. Zapewnia to spójne, pionowe odstępy między wszystkimi polami formularza (Imię, Nazwisko, Email) oraz przyciskiem.
- Usunięto zbędne marginesy z `.form-group`, aby polegać wyłącznie na właściwości `gap`, co upraszcza kod i zapobiega konfliktom stylów.
- Dodano niewielki margines dolny do etykiet (`form-label`) dla lepszej separacji wizualnej od pól input.

Zmiany te adresują prośbę użytkownika o bardziej estetyczny i czytelny układ formularza.