### PR TITLE
feat: Update video list and add sound control

### DIFF
--- a/ting-tong-theme/functions.php
+++ b/ting-tong-theme/functions.php
@@ -135,18 +135,42 @@ function tt_get_slides_data() {
 		[
 			'post_id'      => 1,
 			'post_title'   => 'Paweł Polutek',
-			'post_content' => 'To jest dynamicznie załadowany opis dla pierwszego slajdu. Działa!',
+			'post_content' => 'To jest dynamicznie załadowany opis dla pierwszego slajdu.
+Działa!',
 			'video_url'    => 'https://pawelperfect.pl/wp-content/uploads/2025/07/17169505-hd_1080_1920_30fps.mp4',
 			'access'       => 'public',
+			'comments'     => 567,
 			'avatar'       => 'https://i.pravatar.cc/100?u=pawel',
 		],
 		[
 			'post_id'      => 2,
 			'post_title'   => 'Web Dev',
-			'post_content' => 'Kolejny slajd, kolejne wideo. #efficiency',
+			'post_content' => 'Kolejny slajd, kolejne wideo.
+#efficiency',
 			'video_url'    => 'https://pawelperfect.pl/wp-content/uploads/2025/07/4434150-hd_1080_1920_30fps-1.mp4',
 			'access'       => 'public',
+			'comments'     => 1245,
 			'avatar'       => 'https://i.pravatar.cc/100?u=webdev',
+		],
+		[
+			'post_id'      => 3,
+			'post_title'   => 'Tajemniczy Tester',
+			'post_content' => 'Ten slajd jest tajny!
+🤫',
+			'video_url'    => 'https://pawelperfect.pl/wp-content/uploads/2025/07/4678261-hd_1080_1920_25fps.mp4',
+			'access'       => 'secret',
+			'comments'     => 2,
+			'avatar'       => 'https://i.pravatar.cc/100?u=tester',
+		],
+		[
+			'post_id'      => 4,
+			'post_title'   => 'Artysta AI',
+			'post_content' => 'Generowane przez AI, renderowane przez przeglądarkę.
+#future',
+			'video_url'    => 'https://pawelperfect.pl/wp-content/uploads/2025/07/AdobeStock_631182722-online-video-cutter.com_.mp4',
+			'access'       => 'public',
+			'comments'     => 890,
+			'avatar'       => 'https://i.pravatar.cc/100?u=ai-artist',
 		],
 	];
 


### PR DESCRIPTION
This commit updates the list of simulated video posts in `functions.php` with a new, verified set of video data.

It also introduces a user-controlled sound toggle for the video player to address browser autoplay policies and improve user experience.

- The `$simulated_posts` array in `tt_get_slides_data()` has been replaced with a new data set.
- A volume control button has been added to the video player UI in `index.php`.
- The `<video>` tag is kept `muted` by default to ensure autoplay.
- JavaScript logic in `script.js` now manages a global sound state, handles the volume button's click event, and applies the correct mute status to videos as they become active.
- CSS has been added to `style.css` to position the new volume button.