### PR TITLE
Fix: Poprawiono sterowanie wideo i działanie nakładek

### DIFF
--- a/ting-tong-theme/style.css
+++ b/ting-tong-theme/style.css
@@ -351,7 +351,7 @@ body,
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: transparent;
   z-index: 102;
   opacity: 0;
   pointer-events: none;
@@ -366,8 +366,8 @@ body,
 }
 
 .replay-icon {
-  width: 80px;
-  height: 80px;
+  width: 64px;
+  height: 64px;
   color: rgba(255, 255, 255, 0.9);
   filter: drop-shadow(0 0 10px rgba(0, 0, 0, 0.5));
 }


### PR DESCRIPTION
Naprawiono błędy związane z odtwarzaniem wideo i wyświetlaniem nakładek.

- **Pauzowanie wideo:** Zmieniono logikę `handleMediaChange`, aby jawnie pauzować wszystkie filmy w kontenerze Swipera przed odtworzeniem aktywnego slajdu. Rozwiązuje to problem odtwarzania dźwięku z nieaktywnych, zduplikowanych slajdów w trybie pętli.
- **Wygląd ikony powtórzenia:** Usunięto tło z `.replay-overlay` i zmniejszono rozmiar ikony do 64px, aby była bardziej spójna wizualnie.
- **Wykrywanie PWA:** Ulepszono funkcję `isStandalone` poprzez dodanie warunku `window.navigator.standalone` dla lepszej kompatybilności z iOS, co naprawia logikę wyświetlania nakładki "Secret PWA".