### PR TITLE
Fix: Center and constrain PWA bar on desktop

### DIFF
--- a/ting-tong-theme/style.css
+++ b/ting-tong-theme/style.css
@@ -3513,6 +3513,18 @@ body,
     right: 0; /* POPRAWKA: Niezbędne do centrowania elementu fixed/absolute */
   }
 
+  /* [FIX] Centrowanie i ograniczanie szerokości paska PWA na desktopie */
+  .pwa-prompt,
+  .pwa-prompt-ios {
+    width: calc(100vh * 9 / 16);
+    max-width: 100%;
+    left: 0;
+    right: 0;
+    margin: 0 auto;
+    border-left: 1px solid #333;
+    border-right: 1px solid #333;
+  }
+
   /* Body - tło po bokach */
   body {
     background: linear-gradient(135deg, #1a1a1a 0%, #2d2d2d 100%);


### PR DESCRIPTION
The PWA installation bar was previously stretching to the full viewport width on desktop screens, which was inconsistent with the main application frame that is centered and constrained to a 9:16 aspect ratio.

This change adds CSS rules to the `@media (min-width: 600px)` query to:
- Constrain the width of `.pwa-prompt` and `.pwa-prompt-ios` to match the app frame.
- Center the bar horizontally.
- Add left and right borders for visual consistency with the main container.