### PR TITLE
Fix: Adjust PWA banner and sidebar positioning

### DIFF
--- a/ting-tong-theme/js/app.js
+++ b/ting-tong-theme/js/app.js
@@ -47,6 +47,39 @@ document.addEventListener("DOMContentLoaded", () => {
         });
       });
 
+      // --- FIX: Zapobiegaj przesunięciu paska PWA przez klawiaturę podczas logowania ---
+      const loginInputs = document.querySelectorAll('#tt-login-form input');
+      const pwaInstallBar = document.getElementById("pwa-install-bar");
+      const appFrame = document.getElementById("app-frame");
+
+      if (loginInputs.length > 0 && pwaInstallBar && appFrame) {
+          const handleInputFocus = () => {
+              // Ukryj pasek PWA i usuń offset z ramki aplikacji
+              pwaInstallBar.style.display = 'none';
+              appFrame.classList.remove("app-frame--pwa-visible");
+          };
+
+          const handleInputBlur = () => {
+              // Poczekaj chwilę, aby upewnić się, że focus nie przeniósł się na inne pole input
+              setTimeout(() => {
+                  const isAnyLoginInputActive = Array.from(loginInputs).some(input => input === document.activeElement);
+
+                  if (!isAnyLoginInputActive && pwaInstallBar.classList.contains("visible")) {
+                      // Pokaż pasek ponownie, jeśli powinien być widoczny (ma klasę 'visible')
+                      pwaInstallBar.style.display = ''; // Przywróć domyślny display (z CSS)
+                      appFrame.classList.add("app-frame--pwa-visible"); // Przywróć offset ramki
+                  }
+              }, 50);
+          };
+
+          loginInputs.forEach(input => {
+              input.addEventListener('focus', handleInputFocus);
+              input.addEventListener('blur', handleInputBlur);
+              // Dodaj touchstart dla szybszej reakcji na urządzeniach mobilnych
+              input.addEventListener('touchstart', handleInputFocus, { passive: true });
+          });
+      }
+
       document.body.addEventListener("click", Handlers.mainClickHandler);
       document.body.addEventListener("submit", Handlers.formSubmitHandler);
 

--- a/ting-tong-theme/style.css
+++ b/ting-tong-theme/style.css
@@ -428,7 +428,7 @@ body,
     (var(--app-height) - var(--topbar-height) - var(--bottombar-height)) / 2 +
       var(--topbar-height)
   );
-  right: -4px;
+  right: 12px; /* Zapewnia widoczność i margines od prawej krawędzi */
   transform: translateY(-50%) translateX(0); /* Od razu na ekranie */
   display: flex;
   flex-direction: column;
@@ -2499,7 +2499,7 @@ body,
   }
 }
 .pwa-prompt {
-  position: fixed;
+  position: absolute;
   bottom: 0;
   left: 0;
   width: 100%;
@@ -2552,7 +2552,7 @@ body,
   pointer-events: auto !important; /* Force clickability */
 }
 .pwa-prompt-ios {
-  position: fixed;
+  position: absolute;
   bottom: 0;
   left: 0;
   width: 100%;


### PR DESCRIPTION
This commit addresses three layout issues:

1.  **PWA Banner Keyboard Overlap:** Changed the `.pwa-prompt` and `.pwa-prompt-ios` elements from `position: fixed` to `position: absolute`. This prevents mobile browsers from pushing the banner up when the virtual keyboard appears, allowing the keyboard to cover it as intended.

2.  **PWA Banner Hiding on Input Focus:** Added a JavaScript listener in `app.js` that detects when a user focuses on an input field within the login form (`#tt-login-form`). When focus is detected, the PWA installation bar is hidden to prevent any visual obstruction. The bar reappears on blur if it was previously visible.

3.  **Sidebar Visibility:** Adjusted the CSS for `.tiktok-symulacja .sidebar` by changing `right: -4px` to `right: 12px`. This ensures the sidebar is correctly positioned within the viewport and is fully visible on desktop simulations.