### PR TITLE
feat: Update login modal and PWA bar behavior

### DIFF
--- a/ting-tong-theme/index.php
+++ b/ting-tong-theme/index.php
@@ -684,7 +684,6 @@ get_header();
 
 <!-- Debug Tools -->
 <div id="debug-tools" style="position: fixed; bottom: 10px; right: 10px; z-index: 10000;">
-    <button id="mock-first-login-btn" style="background: #ff0055; color: white; border: 1px solid white; padding: 5px 10px; font-size: 12px; cursor: pointer; border-radius: 5px;">MOCK MODAL</button>
 </div>
 
 <?php get_footer(); ?>

--- a/ting-tong-theme/js/app.js
+++ b/ting-tong-theme/js/app.js
@@ -48,38 +48,6 @@ document.addEventListener("DOMContentLoaded", () => {
         });
       });
 
-      // --- FIX: Zapobiegaj przesunięciu paska PWA przez klawiaturę podczas logowania ---
-      const loginInputs = document.querySelectorAll('#tt-login-form input');
-      const pwaInstallBar = document.getElementById("pwa-install-bar");
-      const appFrame = document.getElementById("app-frame");
-
-      if (loginInputs.length > 0 && pwaInstallBar && appFrame) {
-          const handleInputFocus = () => {
-              // Ukryj pasek PWA i usuń offset z ramki aplikacji
-              pwaInstallBar.style.display = 'none';
-              appFrame.classList.remove("app-frame--pwa-visible");
-          };
-
-          const handleInputBlur = () => {
-              // Poczekaj chwilę, aby upewnić się, że focus nie przeniósł się na inne pole input
-              setTimeout(() => {
-                  const isAnyLoginInputActive = Array.from(loginInputs).some(input => input === document.activeElement);
-
-                  if (!isAnyLoginInputActive && pwaInstallBar.classList.contains("visible")) {
-                      // Pokaż pasek ponownie, jeśli powinien być widoczny (ma klasę 'visible')
-                      pwaInstallBar.style.display = ''; // Przywróć domyślny display (z CSS)
-                      appFrame.classList.add("app-frame--pwa-visible"); // Przywróć offset ramki
-                  }
-              }, 50);
-          };
-
-          loginInputs.forEach(input => {
-              input.addEventListener('focus', handleInputFocus);
-              input.addEventListener('blur', handleInputBlur);
-              // Dodaj touchstart dla szybszej reakcji na urządzeniach mobilnych
-              input.addEventListener('touchstart', handleInputFocus, { passive: true });
-          });
-      }
 
       document.body.addEventListener("click", Handlers.mainClickHandler);
       document.body.addEventListener("submit", Handlers.formSubmitHandler);

--- a/ting-tong-theme/js/modules/first-login-modal.js
+++ b/ting-tong-theme/js/modules/first-login-modal.js
@@ -71,13 +71,6 @@ function setupEventListeners() {
     form.addEventListener('submit', handleFormSubmit);
   }
 
-  // Mock button for testing
-  const mockBtn = document.getElementById("mock-first-login-btn");
-  if (mockBtn) {
-    mockBtn.addEventListener("click", () => {
-      showFirstLoginModal('test-user@example.com');
-    });
-  }
 }
 
 /**
@@ -435,7 +428,7 @@ function showSuccess(message) {
  * @returns {boolean}
  */
 function shouldShowFirstLoginModal(loginResponse) {
-  return loginResponse?.data?.requires_first_login_setup === true;
+  return true;
 }
 
 // Export


### PR DESCRIPTION
This commit addresses three user requests:

1.  The first login modal is now configured to display after every successful login. The mock button used for testing this modal has been removed.
2.  The PWA installation bar no longer disappears when an input field is focused in the browser. The existing logic that hides the bar in standalone PWA mode has been preserved.
3.  The video player's tap-to-play/pause functionality was confirmed to be working as expected, so no code changes were necessary for this feature.