### PR TITLE
Fix: Improve PWA bar detection and visibility

### DIFF
--- a/ting-tong-theme/index.php
+++ b/ting-tong-theme/index.php
@@ -406,7 +406,7 @@ get_header();
     </div>
 <input type="file" class="file-input" id="avatarFileInput" accept="image/*">
 
-<div id="pwa-install-bar" class="pwa-prompt">
+<div id="pwa-install-bar" class="pwa-prompt" aria-hidden="true" style="display: none;">
     <div class="pwa-prompt-content">
         <p class="pwa-prompt-title" data-translate-key="installPwaHeading">Zobacz więcej!</p>
         <p class="pwa-prompt-description">

--- a/ting-tong-theme/style.css
+++ b/ting-tong-theme/style.css
@@ -3043,9 +3043,11 @@ body,
   transform: translateY(100%);
   transition: transform 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94);
   visibility: hidden;
+  display: none; /* DODANE: domyślnie całkowicie ukryty */
   height: var(--bottombar-height);
 }
 .pwa-prompt.visible {
+  display: flex; /* DODANE: musi nadpisać display: none */
   transform: translateY(0);
   visibility: visible;
 }
@@ -4096,15 +4098,33 @@ body,
   }
 }
 
-/* Ukryj pasek PWA w trybie standalone (jako dodatkowe zabezpieczenie) */
+/* WZMOCNIONE ukrywanie w trybie standalone */
 @media (display-mode: standalone) {
   .pwa-prompt,
   .pwa-prompt-ios {
     display: none !important;
+    visibility: hidden !important;
+    opacity: 0 !important;
+    pointer-events: none !important;
+    height: 0 !important;
+    overflow: hidden !important;
   }
 
   #app-frame.app-frame--pwa-visible {
     height: 100% !important;
+  }
+}
+
+/* DODAJ TAKŻE dla iOS */
+@media (display-mode: fullscreen) {
+  .pwa-prompt,
+  .pwa-prompt-ios {
+    display: none !important;
+    visibility: hidden !important;
+    opacity: 0 !important;
+    pointer-events: none !important;
+    height: 0 !important;
+    overflow: hidden !important;
   }
 }
 


### PR DESCRIPTION
Implements a more robust PWA standalone detection mechanism in `js/modules/pwa.js` using five different methods.

Refactors the PWA check initialization to be more efficient, avoiding unnecessary repeated checks.

Updates `style.css` to hide the PWA bar with `display: none` by default, preventing it from flashing on load.

Strengthens the CSS rules to ensure the PWA bar is hidden when the app is in standalone or fullscreen mode.

Updates `index.php` to set the correct initial `aria-hidden` and `style` attributes for the PWA bar.

The "tap-to-pause" functionality was verified to be already present and correct.