### PR TITLE
Fix UI not appearing in PWA mode

### DIFF
--- a/ting-tong-theme/js/app.js
+++ b/ting-tong-theme/js/app.js
@@ -210,6 +210,17 @@ document.addEventListener("DOMContentLoaded", () => {
 
         _verifyLoginState(); // Async verification in background
         UI.renderSlides();
+
+        // ✅ FIX: Fallback - pokaż UI po 2 sekundach nawet jeśli video się nie załadowało
+        setTimeout(() => {
+          document.querySelectorAll('.tiktok-symulacja').forEach(sim => {
+            if (!sim.classList.contains('video-loaded')) {
+              console.log('Forcing video-loaded class after timeout for slide:', sim.closest('.webyx-section')?.dataset.slideId);
+              sim.classList.add('video-loaded');
+            }
+          });
+        }, 2000);
+
         UI.updateTranslations();
 
         const handleMediaChange = (swiper) => {

--- a/ting-tong-theme/js/modules/ui.js
+++ b/ting-tong-theme/js/modules/ui.js
@@ -436,10 +436,35 @@ function createSlideElement(slideData, index) {
   const progressBarFill = section.querySelector(".progress-bar-fill");
 
   if (videoEl) {
+    // ✅ FIX: Pokaż UI od razu po załadowaniu metadanych, nie czekaj na odtwarzanie
     videoEl.addEventListener(
-      "playing",
+      "loadedmetadata",
       () => {
         tiktokSymulacja.classList.add("video-loaded");
+      },
+      { once: true },
+    );
+
+    // Spróbuj odtworzyć (może zadziałać lub nie - ale UI już będzie widoczny)
+    videoEl.addEventListener(
+      "canplay",
+      () => {
+        // Tylko jeśli to aktywny slajd i brak overlay
+        if (section.classList.contains('swiper-slide-active')) {
+          const secretOverlay = section.querySelector('.secret-overlay');
+          const pwaSecretOverlay = section.querySelector('.pwa-secret-overlay');
+          const isOverlayVisible =
+            (secretOverlay && secretOverlay.classList.contains('visible')) ||
+            (pwaSecretOverlay && pwaSecretOverlay.classList.contains('visible'));
+
+          if (!isOverlayVisible && videoEl.paused) {
+            videoEl.play().catch(e => {
+              console.log("Autoplay prevented, showing pause overlay");
+              const pauseOverlay = section.querySelector('.pause-overlay');
+              if (pauseOverlay) pauseOverlay.classList.add('visible');
+            });
+          }
+        }
       },
       { once: true },
     );


### PR DESCRIPTION
The sidebar and bottom bar were not visible in PWA mode because their visibility was dependent on the video's "playing" event. Since autoplay can be blocked in PWAs, this event would never fire, leaving the UI hidden.

This commit implements a two-part solution based on the user's diagnosis:
1. In `js/modules/ui.js`, the event listener that adds the `video-loaded` class is changed from `playing` to `loadedmetadata`. This makes the UI appear as soon as video metadata is available, without waiting for playback.
2. In `js/app.js`, a 2-second `setTimeout` fallback is added. This forcefully adds the `video-loaded` class if it hasn't been added by the event listener, ensuring the UI always becomes visible even if video events fail entirely.