### PR TITLE
Fix desktop layout to correctly simulate phone feed

### DIFF
--- a/ting-tong-theme/style.css
+++ b/ting-tong-theme/style.css
@@ -4181,3 +4181,118 @@ body,
     display: none;
   }
 }
+
+/* ============================================================================
+   DESKTOP FIX - Zapewnienie poprawnego układu w trybie symulacji telefonu
+   ============================================================================ */
+
+@media (min-width: 600px) {
+  /* ✅ FIX 1: Sekcje muszą używać 100% zamiast 100vw */
+  .webyx-section {
+    width: 100%; /* Zmiana z 100vw na 100% */
+    height: 100vh;
+    height: var(--app-height);
+  }
+
+  /* ✅ FIX 2: Video musi mieć object-fit: cover i być w granicach kontenera */
+  .player,
+  .tiktok-symulacja video {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover; /* KRYTYCZNE: zapobiega rozciąganiu */
+    object-position: center;
+  }
+
+  /* ✅ FIX 3: Iframe też musi być w granicach */
+  .tiktok-symulacja iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  /* ✅ FIX 4: Sidebar - upewnij się że jest widoczny i dobrze pozycjonowany */
+  .tiktok-symulacja .sidebar {
+    display: flex; /* Wymuszenie widoczności */
+    visibility: visible !important; /* Na wypadek gdyby coś go ukrywało */
+  }
+
+  /* ✅ FIX 5: Wszystkie overlay muszą używać 100% zamiast 100vw */
+  .secret-overlay,
+  .pwa-secret-overlay,
+  .error-overlay,
+  .pause-overlay,
+  .replay-overlay {
+    width: 100%;
+  }
+
+  /* ✅ FIX 6: Topbar i bottombar też muszą być w granicach */
+  .topbar,
+  .tiktok-symulacja .bottombar {
+    width: 100%;
+  }
+
+  /* ✅ FIX 7: Login panel - dopasowanie do zwężonego kontenera */
+  .login-panel {
+    width: 100%;
+  }
+
+  /* ✅ FIX 8: Swiper wrapper - musi być w granicach */
+  .swiper-wrapper {
+    width: 100%;
+  }
+
+  /* ✅ FIX 9: Alert box - centrowanie w zwężonym kontenerze */
+  #alertBox {
+    left: 50%;
+    transform: translateX(-50%);
+    max-width: calc(100% - 40px); /* Odstępy od krawędzi */
+  }
+
+  /* ✅ FIX 10: Video controls - zapewnienie widoczności */
+  .video-controls {
+    display: flex !important;
+    z-index: 105;
+  }
+
+  /* ✅ FIX 11: Progress bar - pełna szerokość w kontenerze */
+  .progress-bar {
+    width: 100%;
+    left: 0;
+  }
+
+  /* ✅ FIX 12: Bottombar text info - zapewnienie widoczności */
+  .tiktok-symulacja .text-info {
+    display: block;
+    max-width: calc(100% - 80px); /* Odstęp od sidebara */
+  }
+}
+
+/* ============================================================================
+   DODATKOWE ZABEZPIECZENIA - dla wszystkich szerokości ekranu
+   ============================================================================ */
+
+/* Video zawsze z object-fit */
+.player,
+.tiktok-symulacja video {
+  object-fit: cover;
+  object-position: center;
+}
+
+/* Zapobieganie overflow */
+.webyx-section,
+.tiktok-symulacja {
+  overflow: hidden;
+}
+
+/* Sidebar zawsze widoczny gdy video załadowane */
+.tiktok-symulacja.video-loaded .sidebar {
+  opacity: 1 !important;
+  visibility: visible !important;
+  display: flex !important;
+}


### PR DESCRIPTION
On viewports wider than 600px, the theme simulates a vertical phone feed. However, several elements were using `100vw` for their width, causing them to stretch across the entire browser window instead of being constrained to the phone-like container. Additionally, videos were stretching to fill their container, breaking their aspect ratio.

This commit fixes the layout by:
- Changing `width: 100vw` to `width: 100%` for main sections, overlays, and bars to respect the parent container's width.
- Applying `object-fit: cover` to videos and iframes to prevent distortion.
- Forcing the sidebar and other UI elements to be visible and correctly positioned within the narrowed container on desktop.