### PR TITLE
Fix(css): Ensure progress bar is always visible above PWA prompt

### DIFF
--- a/ting-tong-theme/style.css
+++ b/ting-tong-theme/style.css
@@ -1011,7 +1011,7 @@ body,
   justify-content: flex-start;
   padding: 10px 75px 10px 12px;
   color: white;
-  z-index: 10006;
+  z-index: 10050;
   padding-bottom: calc(10px + var(--safe-area-bottom));
 
   /* ✅ NOWE: Ukryj bottombar domyślnie */
@@ -1037,7 +1037,7 @@ body,
   -webkit-tap-highlight-color: transparent;
   display: flex;
   align-items: center;
-  z-index: 10010;
+  z-index: 10050;
 }
 
 .progress-bar::before {
@@ -4023,10 +4023,6 @@ body,
   text-decoration: none !important;
 }
 
-.app-frame--pwa-visible .progress-bar {
-  top: auto;
-  bottom: 100%;
-}
 
 .form-row {
   display: flex;
@@ -4283,13 +4279,6 @@ body,
   display: flex !important;
 }
 
-/* Dostosowanie dla przeglądarki (nie-PWA) */
-@media not all and (display-mode: standalone) {
-  .progress-bar {
-    bottom: 100%;
-    top: auto;
-  }
-}
 }/*
 Theme Name: Ting Tong Theme
 Theme URI: https://example.com/ting-tong-theme/


### PR DESCRIPTION
Increased the z-index of the .progress-bar and .bottombar to 10050 to ensure they render above the PWA installation prompt (z-index: 10002).

Removed conditional CSS rules that shifted the progress bar's position based on PWA visibility or browser mode. This ensures the progress bar remains in a consistent, fixed position at the top of the bottom bar across all application states.